### PR TITLE
Import ViciValvo in local __init__

### DIFF
--- a/flowchem/devices/ViciValco/__init__.py
+++ b/flowchem/devices/ViciValco/__init__.py
@@ -1,0 +1,1 @@
+from .ViciValco_Actuator import ViciValco


### PR DESCRIPTION
without this on the import in devices/__init__.py is useless.

The aim of all these relative imports is to have all the device classes in the top level, allowing two things:
Device import with no knowledge of the package inner structure:
```python
from flowchem import ViciValco
```
and it simplifies the instantiation of devices from config (see `get_device_class_mapper` in `flowchem.server.main`)