### PR TITLE
Support for Custom ML600 Configurations

### DIFF
--- a/docs/user-guides/reference/devices/pumps/ml600.md
+++ b/docs/user-guides/reference/devices/pumps/ml600.md
@@ -30,6 +30,30 @@ automatically used:
 * bytesize 7
 ```
 
+```{note} Support for Custom ML600 Configurations
+The ML600 device supports custom configurations for pump and valve connections. 
+```
+Since the ML600 hardware allows for customizable valve setups, `FlowChem` supports this flexibility to ensure accurate 
+device configuration and operation. This is particularly important for identifying which valve is connected to which 
+pump.
+
+You can specify the desired valve class(es) directly in the device configuration block using the following options:
+
+### Dual-Syringe Setup
+
+For devices with two syringe pumps, you can independently assign valve classes to each side:
+```toml
+valve_left_class = "ML600LeftValve"    # Options: "ML600LeftValve" or "ML600RightValve"
+valve_right_class = "ML600RightValve"  # Options: "ML600LeftValve" or "ML600RightValve"
+```
+
+### Single-Syringe Setup
+
+For devices with a single syringe pump, specify only one valve class:
+```toml
+valve_class = "ML600LeftValve"  # Options: "ML600LeftValve" or "ML600RightValve"
+```
+
 ## API methods
 See the [device API reference](../../api/ml600/api.md) for a description of the available methods.
 

--- a/docs/user-guides/reference/devices/pumps/ml600.md
+++ b/docs/user-guides/reference/devices/pumps/ml600.md
@@ -37,6 +37,8 @@ Since the ML600 hardware allows for customizable valve setups, `FlowChem` suppor
 device configuration and operation. This is particularly important for identifying which valve is connected to which 
 pump.
 
+## Custom device
+
 You can specify the desired valve class(es) directly in the device configuration block using the following options:
 
 ### Dual-Syringe Setup

--- a/docs/user-guides/reference/devices/pumps/ml600.md
+++ b/docs/user-guides/reference/devices/pumps/ml600.md
@@ -45,16 +45,18 @@ You can specify the desired valve class(es) directly in the device configuration
 
 For devices with two syringe pumps, you can independently assign valve classes to each side:
 ```toml
-valve_left_class = "ML600LeftValve"    # Options: "ML600LeftValve" or "ML600RightValve"
-valve_right_class = "ML600RightValve"  # Options: "ML600LeftValve" or "ML600RightValve"
+left_valve = "ML600LeftValve"    # Options: "ML600LeftValve" or "ML600RightValve"
+right_valve = "ML600RightValve"  # Options: "ML600LeftValve" or "ML600RightValve"
 ```
 
 ### Single-Syringe Setup
 
 For devices with a single syringe pump, specify only one valve class:
 ```toml
-valve_class = "ML600LeftValve"  # Options: "ML600LeftValve" or "ML600RightValve"
+left_valve = "ML600LeftValve"  # Options: "ML600LeftValve" or "ML600RightValve"
 ```
+
+It is worth noting that, as a standard setting, the single-syringe pump is equipped with a left valve.
 
 ## API methods
 See the [device API reference](../../api/ml600/api.md) for a description of the available methods.

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -421,12 +421,12 @@ class ML600(FlowchemDevice):
         # Add device components
         if self.dual_syringe:
             self.components.extend([ML600Pump("left_pump", self, "B"), ML600Pump("right_pump", self, "C")])
-            if self.config.get("valve_position_left", "") == "ML600RightValve":
+            if self.config.get("valve_left_class", "") == "ML600RightValve":
                 self.components.extend([ML600RightValve("left_valve", self)])
             else:
                 self.components.extend([ML600LeftValve("left_valve", self)])
 
-            if self.config.get("valve_position_rigth", "") == "ML600LeftValve":
+            if self.config.get("valve_rigth_class", "") == "ML600LeftValve":
                 self.components.extend([ML600LeftValve("right_valve", self)])
             else:
                 self.components.extend([ML600RightValve("right_valve", self)])

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -361,17 +361,17 @@ class ML600(FlowchemDevice):
         if config.get("valve_left_class") and config.get("valve_left_class") not in ValveType:
             logger.error(f"Invalid valve configuration in left valve of {self.name}!")
             logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
-            logger.error(f"Assuming {ML600.DEFAULT_CONFIG["valve_left_class"]}!")
+            logger.error("Assuming default configuration!")
             config.pop("valve_left_class")
         if config.get("valve_rigth_class") and config.get("valve_rigth_class") not in ValveType:
             logger.error(f"Invalid valve configuration in rigth valve of {self.name}!")
             logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
-            logger.error(f"Assuming {ML600.DEFAULT_CONFIG["valve_rigth_class"]}!")
+            logger.error("Assuming default configuration!")
             config.pop("valve_rigth_class")
         if config.get("valve_class") and config.get("valve_class") not in ValveType:
             logger.error(f"Invalid valve configuration in valve of {self.name}!")
             logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
-            logger.error(f"Assuming {ML600.DEFAULT_CONFIG["valve_class"]}!")
+            logger.error("Assuming default configuration!")
             config.pop("valve_class")
         # This will merger the config into ML600.DEFAULT_CONFIG (in order to update)
         self.config = ML600.DEFAULT_CONFIG | config

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -274,7 +274,7 @@ class ML600(FlowchemDevice):
         "default_infuse_rate": "1 ml/min",
         "default_withdraw_rate": "1 ml/min",
         "valve_left_class": ValveType.LEFT.value,     # for device with two syringe pump and two valve
-        "valve_rigth_class": ValveType.RIGHT.value,   # for device with two syringe pump and two valve
+        "valve_right_class": ValveType.RIGHT.value,   # for device with two syringe pump and two valve
         "valve_class": ValveType.LEFT.value           # for device with one syringe pump and valve
     }
 
@@ -363,7 +363,7 @@ class ML600(FlowchemDevice):
             logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
             logger.error("Assuming default configuration!")
             config.pop("valve_left_class")
-        if config.get("valve_rigth_class") and config.get("valve_rigth_class") not in ValveType:
+        if config.get("valve_right_class") and config.get("valve_rigtht_class") not in ValveType:
             logger.error(f"Invalid valve configuration in rigth valve of {self.name}!")
             logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
             logger.error("Assuming default configuration!")

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -359,19 +359,19 @@ class ML600(FlowchemDevice):
 
     def inspect_valve_argument(self, config: dict):
         if config.get("valve_left_class") and config.get("valve_left_class") not in ValveType:
-            logger.error(f"Invalid valve configuration in left valve of {self.name}! "
-                         f"Supported valve types are: {[v.value for v in ValveType]}. Assuming "
-                         f"{ML600.DEFAULT_CONFIG["valve_left_class"]}!")
+            logger.error(f"Invalid valve configuration in left valve of {self.name}!")
+            logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
+            logger.error(f"Assuming {ML600.DEFAULT_CONFIG["valve_left_class"]}!")
             config.pop("valve_left_class")
         if config.get("valve_rigth_class") and config.get("valve_rigth_class") not in ValveType:
-            logger.error(f"Invalid valve configuration in rigth valve of {self.name}! "
-                         f"Supported valve types are: {[v.value for v in ValveType]}. Assuming "
-                         f"{ML600.DEFAULT_CONFIG["valve_rigth_class"]}!")
+            logger.error(f"Invalid valve configuration in rigth valve of {self.name}!")
+            logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
+            logger.error(f"Assuming {ML600.DEFAULT_CONFIG["valve_rigth_class"]}!")
             config.pop("valve_rigth_class")
         if config.get("valve_class") and config.get("valve_class") not in ValveType:
-            logger.error(f"Invalid valve configuration in valve of {self.name}! "
-                         f"Supported valve types are: {[v.value for v in ValveType]}. Assuming "
-                         f"{ML600.DEFAULT_CONFIG["valve_class"]}!")
+            logger.error(f"Invalid valve configuration in valve of {self.name}!")
+            logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
+            logger.error(f"Assuming {ML600.DEFAULT_CONFIG["valve_class"]}!")
             config.pop("valve_class")
         # This will merger the config into ML600.DEFAULT_CONFIG (in order to update)
         self.config = ML600.DEFAULT_CONFIG | config

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -358,23 +358,23 @@ class ML600(FlowchemDevice):
         self.dual_syringe = False
 
     def inspect_valve_argument(self, config: dict):
-        if config.get("valve_left_class") and not config.get("valve_left_class") in ValveType:
+        if config.get("valve_left_class") and config.get("valve_left_class") not in ValveType:
             logger.error(f"Invalid valve configuration in left valve of {self.name}! "
                          f"Supported valve types are: {[v.value for v in ValveType]}. Assuming "
                          f"{ML600.DEFAULT_CONFIG["valve_left_class"]}!")
             config.pop("valve_left_class")
-        if config.get("valve_rigth_class") and not config.get("valve_rigth_class") in ValveType:
+        if config.get("valve_rigth_class") and config.get("valve_rigth_class") not in ValveType:
             logger.error(f"Invalid valve configuration in rigth valve of {self.name}! "
                          f"Supported valve types are: {[v.value for v in ValveType]}. Assuming "
                          f"{ML600.DEFAULT_CONFIG["valve_rigth_class"]}!")
             config.pop("valve_rigth_class")
-        if config.get("valve_class") and not config.get("valve_class") in ValveType:
+        if config.get("valve_class") and config.get("valve_class") not in ValveType:
             logger.error(f"Invalid valve configuration in valve of {self.name}! "
                          f"Supported valve types are: {[v.value for v in ValveType]}. Assuming "
                          f"{ML600.DEFAULT_CONFIG["valve_class"]}!")
             config.pop("valve_class")
         # This will merger the config into ML600.DEFAULT_CONFIG (in order to update)
-        self.config = VirtualML600.DEFAULT_CONFIG | config
+        self.config = ML600.DEFAULT_CONFIG | config
 
     @classmethod
     def from_config(cls, **config):

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -5,7 +5,7 @@ import asyncio
 import string
 import warnings
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import TYPE_CHECKING
 
 import aioserial
@@ -253,7 +253,7 @@ class ML600Commands(Enum):
     OPTIONAL_PARAMETER = "S"
 
 
-class ValveType(Enum):
+class ValveType(StrEnum):
     """Enum for supported valve types in ML600."""
     LEFT = "ML600LeftValve"
     RIGHT = "ML600RightValve"
@@ -273,9 +273,9 @@ class ML600(FlowchemDevice):
     DEFAULT_CONFIG = {
         "default_infuse_rate": "1 ml/min",
         "default_withdraw_rate": "1 ml/min",
-        "valve_left_class": ValveType.LEFT.value,     # for device with two syringe pump and two valve
-        "valve_right_class": ValveType.RIGHT.value,   # for device with two syringe pump and two valve
-        "valve_class": ValveType.LEFT.value           # for device with one syringe pump and valve
+        "valve_left_class": ValveType.LEFT,     # for device with two syringe pump and two valve
+        "valve_right_class": ValveType.RIGHT,   # for device with two syringe pump and two valve
+        "valve_class": ValveType.LEFT           # for device with one syringe pump and valve
     }
 
     # This class variable is used for daisy chains (i.e. multiple pumps on the same serial connection). Details below.

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -273,9 +273,9 @@ class ML600(FlowchemDevice):
     DEFAULT_CONFIG = {
         "default_infuse_rate": "1 ml/min",
         "default_withdraw_rate": "1 ml/min",
-        "valve_left_class": ValveType.LEFT,     # for device with two syringe pump and two valve
-        "valve_right_class": ValveType.RIGHT,   # for device with two syringe pump and two valve
-        "valve_class": ValveType.LEFT           # for device with one syringe pump and valve
+        "valve_left_class": ValveType.LEFT,     # for device with two syringe pumps and two valves
+        "valve_right_class": ValveType.RIGHT,   # for device with two syringe pumps and two valves
+        "valve_class": ValveType.LEFT           # for device with one syringe pump and one valve
     }
 
     # This class variable is used for daisy chains (i.e. multiple pumps on the same serial connection). Details below.
@@ -363,17 +363,17 @@ class ML600(FlowchemDevice):
             logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
             logger.error("Assuming default configuration!")
             config.pop("valve_left_class")
-        if config.get("valve_right_class") and config.get("valve_rigtht_class") not in ValveType:
-            logger.error(f"Invalid valve configuration in rigth valve of {self.name}!")
+        if config.get("valve_right_class") and config.get("valve_right_class") not in ValveType:
+            logger.error(f"Invalid valve configuration in right valve of {self.name}!")
             logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
             logger.error("Assuming default configuration!")
-            config.pop("valve_rigth_class")
+            config.pop("valve_right_class")
         if config.get("valve_class") and config.get("valve_class") not in ValveType:
             logger.error(f"Invalid valve configuration in valve of {self.name}!")
             logger.error(f"Supported valve types are: {[v.value for v in ValveType]}.")
             logger.error("Assuming default configuration!")
             config.pop("valve_class")
-        # This will merger the config into ML600.DEFAULT_CONFIG (in order to update)
+        # This will merge the config into ML600.DEFAULT_CONFIG (in order to update)
         self.config = ML600.DEFAULT_CONFIG | config
 
     @classmethod
@@ -400,7 +400,7 @@ class ML600(FlowchemDevice):
             }
             pumpio = HamiltonPumpIO.from_config(config_for_pumpio)
 
-        # Only get the kwargs that match with the DEFALT one, in order to update it!
+        # Only get the kwargs that match with the DEFAULT one, in order to update it!
         configuration = {
             k: config[k]
             for k in cls.DEFAULT_CONFIG.keys()
@@ -455,7 +455,7 @@ class ML600(FlowchemDevice):
 
             # Handle valve configuration
             left_valve = ValveType(self.config["valve_left_class"])
-            right_valve = ValveType(self.config["valve_rigth_class"])
+            right_valve = ValveType(self.config["valve_right_class"])
             self.components.extend([
                 ML600LeftValve("left_valve", self) if left_valve == ValveType.LEFT else ML600RightValve("left_valve",
                                                                                                         self),

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -391,7 +391,7 @@ class ML600(FlowchemDevice):
             config_for_pumpio = {
                 k: v
                 for k, v in config.items()
-                if k not in ("syringe_volume", "address", "name") and k not in cls.DEFAULT_CONFIG
+                if k not in ("syringe_volume", "address", "name", *cls.DEFAULT_CONFIG.keys())
             }
             pumpio = HamiltonPumpIO.from_config(config_for_pumpio)
 


### PR DESCRIPTION
Since the ML600 hardware allows for customizable valve setups, `FlowChem` must support this flexibility to ensure accurate device configuration and operation. This is particularly important for identifying which valve is connected to which pump.