### PR TITLE
On every push or PR, sphinx-apidoc will re-generate the API documentation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -47,3 +47,6 @@ jobs:
 
       - name: Run pytest
         run: python -m pytest --cov=flowchem --cov-fail-under=40
+
+      - name: Generate API docs
+        run: sphinx-apidoc -o docs/development/foundations/code_structure src


### PR DESCRIPTION
This pull request adds a new step to the GitHub Actions workflow for the Python application. The change introduces automatic generation of API documentation during the CI process.

Documentation automation:

Added a step to run `sphinx-apidoc` and generate API documentation from the `src` directory, placing the output in `docs/development/foundations/code_structure`.