### PR TITLE
fix(server): preserve raw config for /config endpoint

### DIFF
--- a/src/flowchem/server/core.py
+++ b/src/flowchem/server/core.py
@@ -5,6 +5,7 @@ import threading
 from io import BytesIO
 from pathlib import Path
 from typing import Any
+from copy import deepcopy
 
 from loguru import logger
 
@@ -79,7 +80,7 @@ class Flowchem:
 
     async def setup(self, config: BytesIO | Path):
         self.config = parse_config(config)
-        self.http.configuration_dict = self.config
+        self.http.configuration_dict = deepcopy(self.config)
         self.devices = instantiate_device_from_config(self.config)
 
         """Initialize connection to devices and create API endpoints."""


### PR DESCRIPTION
This pull request makes a minor update to the server setup logic to ensure configuration isolation. Specifically, it now uses a deep copy of the configuration when assigning it to the HTTP server, preventing unintended side effects from shared references.

- Server configuration management:
  * [`src/flowchem/server/core.py`]
  
  Imported `deepcopy` and updated the assignment of `self.http.configuration_dict` to use a deep copy of the configuration, ensuring that changes to the HTTP server's configuration do not affect the original configuration object.