### PR TITLE
Ping method exposed

### DIFF
--- a/src/flowchem/__main__.py
+++ b/src/flowchem/__main__.py
@@ -48,9 +48,6 @@ def main(device_config_file, logfile, host, debug):
         host: IP on which the server will be listening. Loopback IP as default, use LAN IP to enable remote access.
         debug: Print debug info
     """
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     if not debug:
         # Set stderr to info
         logger.remove()

--- a/src/flowchem/components/analytics/ir.py
+++ b/src/flowchem/components/analytics/ir.py
@@ -3,6 +3,7 @@
 from pydantic import BaseModel
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 
 
@@ -37,3 +38,12 @@ class IRControl(FlowchemComponent):
     async def stop(self):
         """Stop acquisition and exit gracefully."""
         ...
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Not implemented at the base IR class level.
+
+        The IRControl base class has no device-independent read-only probe.
+        Subclasses backed by a real instrument (e.g. IcIRControl) should
+        override this with a device-specific connectivity check.
+        """
+        return ReachabilityStatus.UNKNOWN

--- a/src/flowchem/components/fakecomponentclass/fakecomponent.py
+++ b/src/flowchem/components/fakecomponentclass/fakecomponent.py
@@ -1,6 +1,7 @@
 """Base FakeComponent."""
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 
 
@@ -41,3 +42,6 @@ class FakeComponent(FlowchemComponent):
         This function demonstrates how the commands request of data can be sent through the API build
         """
         ...
+    
+    async def is_reachable(self) -> ReachabilityStatus:
+        return ReachabilityStatus.ONLINE  # fake device is always on

--- a/src/flowchem/components/fakecomponentclass/fakecomponent.py
+++ b/src/flowchem/components/fakecomponentclass/fakecomponent.py
@@ -42,6 +42,6 @@ class FakeComponent(FlowchemComponent):
         This function demonstrates how the commands request of data can be sent through the API build
         """
         ...
-    
+
     async def is_reachable(self) -> ReachabilityStatus:
         return ReachabilityStatus.ONLINE  # fake device is always on

--- a/src/flowchem/components/flowchem_component.py
+++ b/src/flowchem/components/flowchem_component.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter
 from loguru import logger
 
 from flowchem.components.component_info import ComponentInfo
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from flowchem.devices.flowchem_device import FlowchemDevice
@@ -73,6 +74,8 @@ class FlowchemComponent:
             response_model=ComponentInfo,
         )
 
+        self.add_api_route("/is-reachable", self.is_reachable, methods=["GET"])
+
     @property
     def router(self):
         """
@@ -117,3 +120,13 @@ class FlowchemComponent:
             Metadata about the component.
         """
         return self.component_info
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Check whether the device is reachable and operational.
+
+        Subclasses should override this with the most appropriate read-only probe
+        for their hardware (e.g. reading a channel state, querying a position).
+        Returns UNKNOWN by default so components without a probe do not falsely
+        report the device as offline.
+        """
+        return ReachabilityStatus.UNKNOWN

--- a/src/flowchem/components/meta_components/gantry3D.py
+++ b/src/flowchem/components/meta_components/gantry3D.py
@@ -1,6 +1,7 @@
 """Base Gantry3D meta component."""
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.components.technical.length import LengthControl
 from flowchem.devices.flowchem_device import FlowchemDevice
 
@@ -83,6 +84,15 @@ class Gantry3D(FlowchemComponent):
             position = float(position) if "." in position else int(position)
         await self.z_axis.set_position(position)
         return True
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Not implemented at the Gantry3D base level.
+
+        Gantry3D only exposes axis-positioning (PUT) commands; there is no
+        device-independent read-only probe. Subclasses backed by real hardware
+        (e.g. AutosamplerGantry3D) should override with a device-specific query.
+        """
+        return ReachabilityStatus.UNKNOWN
 
 
 gantry3D = Gantry3D

--- a/src/flowchem/components/pumps/pump.py
+++ b/src/flowchem/components/pumps/pump.py
@@ -1,6 +1,7 @@
 """Base pump component."""
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 
 
@@ -38,3 +39,15 @@ class Pump(FlowchemComponent):
     async def withdraw(self, rate: str = "", volume: str = "") -> bool:
         """Pump in the opposite direction of infuse."""
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the pump responds to a status query.
+
+        Delegates to is_pumping(), which every concrete pump overrides with
+        a real hardware query. Any successful response confirms the device is alive.
+        """
+        try:
+            await self.is_pumping()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/reachability.py
+++ b/src/flowchem/components/reachability.py
@@ -1,0 +1,9 @@
+"""Reachability status enum for FlowchemComponent.is_reachable()."""
+
+from enum import Enum
+
+
+class ReachabilityStatus(str, Enum):
+    ONLINE = "online"    # probe succeeded — device responded
+    OFFLINE = "offline"  # probe failed with exception — device didn't respond
+    UNKNOWN = "unknown"  # no probe available — status cannot be determined

--- a/src/flowchem/components/reachability.py
+++ b/src/flowchem/components/reachability.py
@@ -4,6 +4,6 @@ from enum import Enum
 
 
 class ReachabilityStatus(str, Enum):
-    ONLINE = "online"    # probe succeeded — device responded
+    ONLINE = "online"  # probe succeeded — device responded
     OFFLINE = "offline"  # probe failed with exception — device didn't respond
     UNKNOWN = "unknown"  # no probe available — status cannot be determined

--- a/src/flowchem/components/sensors/sensor.py
+++ b/src/flowchem/components/sensors/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.components.technical.ADC import AnalogDigitalConverter
 from flowchem.devices.flowchem_device import FlowchemDevice
 
@@ -49,3 +50,15 @@ class Sensor(AnalogDigitalConverter):
     async def power_off(self):
         """Power off the sensor."""
         return True
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the sensor responds to a read request.
+
+        Delegates to read(), which every concrete sensor overrides with a
+        real hardware measurement. Any successful response confirms the device is alive.
+        """
+        try:
+            await self.read()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/ADC.py
+++ b/src/flowchem/components/technical/ADC.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 
 
@@ -39,3 +40,11 @@ class AnalogDigitalConverter(FlowchemComponent):
             float: The measured or estimated signal value.
         """
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the ADC responds to a read request."""
+        try:
+            await self.read()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/DAC.py
+++ b/src/flowchem/components/technical/DAC.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 
 
@@ -34,6 +35,14 @@ class DigitalAnalogConverter(FlowchemComponent):
         Read the DAC output of a channel.
         """
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the DAC responds to a read request."""
+        try:
+            await self.read()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE
 
     async def set(self, value: str = "0 V") -> bool:
         """

--- a/src/flowchem/components/technical/MultiChannels.py
+++ b/src/flowchem/components/technical/MultiChannels.py
@@ -1,3 +1,4 @@
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.components.technical.ADC import AnalogDigitalConverter
 from flowchem.components.technical.DAC import DigitalAnalogConverter
 from flowchem.components.technical.relay import Relay
@@ -33,6 +34,14 @@ class MultiChannelADC(AnalogDigitalConverter):
         """
         raise NotImplementedError
 
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the multi-channel ADC responds to a read-all request."""
+        try:
+            await self.read_all()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE
+
 
 class MultiChannelDAC(DigitalAnalogConverter):
 
@@ -57,6 +66,15 @@ class MultiChannelDAC(DigitalAnalogConverter):
             True if the value was accepted and applied successfully.
         """
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Not implemented — MultiChannelDAC exposes no channel-free read-only probe.
+
+        read(channel) requires a mandatory channel argument, making it unsuitable
+        as a generic connectivity probe. Device-specific subclasses that have
+        additional read-only queries (e.g. NIDAQAnalogOutput) should override.
+        """
+        return ReachabilityStatus.UNKNOWN
 
 
 class MultiChannelRelay(Relay):
@@ -167,3 +185,15 @@ class MultiChannelRelay(Relay):
                 - 0, 1 → valid relay state.
         """
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the multi-channel relay responds to a channel-states query.
+
+        Uses read_channels_set_point() rather than is_on(channel) because
+        is_on() requires a mandatory channel argument.
+        """
+        try:
+            await self.read_channels_set_point()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/flow.py
+++ b/src/flowchem/components/technical/flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from flowchem.devices.flowchem_device import FlowchemDevice
@@ -41,3 +42,11 @@ class MassFlowController(FlowchemComponent):
     async def stop(self) -> bool:
         """Stop the mass flow controller by setting the flow rate to 0 ml/min."""
         raise NotImplementedError("Subclasses must override this method.")
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the mass flow controller responds to a setpoint query."""
+        try:
+            await self.get_flow_setpoint()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/length.py
+++ b/src/flowchem/components/technical/length.py
@@ -2,6 +2,7 @@
 
 from loguru import logger
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 
 
@@ -125,3 +126,11 @@ class LengthControl(FlowchemComponent):
                 - For continuous mode: [min, max] bounds.
         """
         return self._available_positions
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the axis responds to a position query."""
+        try:
+            await self.get_position()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/photo.py
+++ b/src/flowchem/components/technical/photo.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from flowchem.devices.flowchem_device import FlowchemDevice
@@ -37,3 +38,11 @@ class Photoreactor(FlowchemComponent):
     async def power_off(self):
         """Turn off light."""
         ...
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the photoreactor responds to an intensity query."""
+        try:
+            await self.get_intensity()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/power.py
+++ b/src/flowchem/components/technical/power.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 
 
@@ -21,6 +22,15 @@ class PowerSwitch(FlowchemComponent):
     async def power_off(self):
         """Turn off power."""
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Not implemented — PowerSwitch exposes only power_on()/power_off() (PUT) commands.
+
+        There is no read-only probe available at this level. Subclasses that
+        expose readable state (e.g. PowerControl) should override with a
+        device-specific query.
+        """
+        return ReachabilityStatus.UNKNOWN
 
 
 class PowerControl(PowerSwitch):
@@ -50,3 +60,11 @@ class PowerControl(PowerSwitch):
     async def get_voltage(self) -> float:
         """Return voltage in Volt."""
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the power controller responds to a voltage query."""
+        try:
+            await self.get_voltage()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/pressure.py
+++ b/src/flowchem/components/technical/pressure.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from flowchem import ureg
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from flowchem.devices.flowchem_device import FlowchemDevice
@@ -57,3 +58,11 @@ class PressureControl(FlowchemComponent):
     async def power_off(self):
         """Turn off the pressure control."""
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the pressure controller responds to a pressure query."""
+        try:
+            await self.get_pressure()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/relay.py
+++ b/src/flowchem/components/technical/relay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.components.technical.power import PowerSwitch
 from flowchem.devices.flowchem_device import FlowchemDevice
 
@@ -95,3 +96,15 @@ class Relay(PowerSwitch):
             NotImplementedError: If the method is not overridden by a subclass.
         """
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the relay responds to a state query.
+
+        Delegates to is_on(), which every concrete relay overrides with a
+        real hardware query. Any successful response confirms the device is alive.
+        """
+        try:
+            await self.is_on()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/stirring.py
+++ b/src/flowchem/components/technical/stirring.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from flowchem import ureg
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from flowchem.devices.flowchem_device import FlowchemDevice
@@ -85,3 +86,11 @@ class StirringControl(FlowchemComponent):
     async def is_on(self) -> bool:  # type: ignore
         """Return whether stirring is active."""
         ...
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the stirring controller responds to a speed query."""
+        try:
+            await self.get_speed()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/technical/temperature.py
+++ b/src/flowchem/components/technical/temperature.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from flowchem import ureg
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from flowchem.devices.flowchem_device import FlowchemDevice
@@ -79,3 +80,11 @@ class TemperatureControl(FlowchemComponent):
     async def power_off(self):
         """Turn off temperature control."""
         raise NotImplementedError
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the temperature controller responds to a temperature query."""
+        try:
+            await self.get_temperature()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/components/valves/solenoid.py
+++ b/src/flowchem/components/valves/solenoid.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 
 
@@ -65,6 +66,14 @@ class SolenoidValve(FlowchemComponent):
     async def get_status(self) -> bool:
         """Backward-compatible alias for checking whether the valve is open."""
         return await self.is_open()
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the solenoid valve responds to a state query."""
+        try:
+            await self.is_open()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE
 
 
 class SolenoidValve2Way(SolenoidValve):

--- a/src/flowchem/components/valves/valve.py
+++ b/src/flowchem/components/valves/valve.py
@@ -8,6 +8,7 @@ from typing import Any, List, Optional, Protocol, cast
 from pydantic import BaseModel
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.devices.flowchem_device import FlowchemDevice
 from flowchem.utils.exceptions import InvalidConfigurationError, DeviceError
 
@@ -338,6 +339,14 @@ class Valve(FlowchemComponent):
         This mainly has informative purpose
         """
         return ValveInfo(ports=self._stator_ports, positions=self._positions)
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the valve responds to a position query."""
+        try:
+            await self.get_position()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE
 
     # Philosophy: explicitly specify which ports to connect
     # In case of a simple multiposition valve, it always connects the always open central port to the requested port.

--- a/src/flowchem/devices/dataapex/clarity_hplc_control.py
+++ b/src/flowchem/devices/dataapex/clarity_hplc_control.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from fastapi import Query
 
 from flowchem.components.analytics.hplc import HPLCControl
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from flowchem.devices import Clarity
@@ -47,6 +48,15 @@ class ClarityComponent(HPLCControl):
         super().__init__(name, hw_device)
         # Clarity-specific command
         self.add_api_route("/exit", self.exit, methods=["PUT"])
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Not implemented — Clarity exposes only a mutating command API.
+
+        All communication with ClarityChrom goes through execute_command(), which
+        sends a CLI command to the instrument. There is no read-only status or ping
+        command available, so a safe connectivity probe cannot be made.
+        """
+        return ReachabilityStatus.UNKNOWN
 
     async def exit(self) -> bool:
         """

--- a/src/flowchem/devices/knauer/azura_compact.py
+++ b/src/flowchem/devices/knauer/azura_compact.py
@@ -463,12 +463,6 @@ class AzuraCompact(KnauerEthernetDevice, FlowchemDevice):
 
 
 if __name__ == "__main__":
-    # This is a bug of asyncio on Windows :|
-    import sys
-
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     p = AzuraCompact(ip_address="192.168.1.119")
 
     async def main(pump: AzuraCompact):

--- a/src/flowchem/devices/knauer/knauer_autosampler_component.py
+++ b/src/flowchem/devices/knauer/knauer_autosampler_component.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from .knauer_autosampler import KnauerAutosampler
 
 from flowchem.components.meta_components.gantry3D import Gantry3D
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.components.pumps.syringe_pump import SyringePump
 from flowchem.components.valves.distribution_valves import FourPortDistributionValve
 from flowchem.components.valves.injection_valves import SixPortTwoPositionValve
@@ -313,6 +314,14 @@ class AutosamplerGantry3D(Gantry3D):
             return True
         else:
             return False
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the Knauer autosampler responds to a status query."""
+        try:
+            await self.hw_device.get_status()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE
 
 
 class AutosamplerPump(SyringePump):

--- a/src/flowchem/devices/knauer/knauer_finder.py
+++ b/src/flowchem/devices/knauer/knauer_finder.py
@@ -3,7 +3,6 @@
 import asyncio
 import queue
 import socket
-import sys
 from textwrap import dedent
 
 import ifaddr
@@ -197,10 +196,6 @@ def autodiscover_knauer(network: str = "") -> dict[str, str]:
 
 def knauer_finder(source_ip: str = ""):
     """Execute autodiscovery. This is the entry point of the `knauer-finder` CLI command."""
-    # This is a bug of asyncio on Windows :|
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     # Autodiscover devices (returns dict with MAC as index, IP as value)
     devices = autodiscover_knauer(source_ip)
     dev_config = set()

--- a/src/flowchem/devices/magritek/spinsolve_control.py
+++ b/src/flowchem/devices/magritek/spinsolve_control.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from fastapi import BackgroundTasks
 
 from flowchem.components.analytics.nmr import NMRControl
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from .spinsolve import Spinsolve
@@ -41,6 +42,19 @@ class SpinsolveControl(NMRControl):
             self.hw_device.is_protocol_running,
             methods=["GET"],
         )
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the Spinsolve responds over the network.
+
+        Uses is_protocol_running() as a lightweight read-only probe — the return
+        value (whether a protocol is active) is discarded; any successful response
+        confirms the instrument is reachable.
+        """
+        try:
+            await self.hw_device.is_protocol_running()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE
 
     async def acquire_spectrum(
         self,

--- a/src/flowchem/devices/mettlertoledo/icir_control.py
+++ b/src/flowchem/devices/mettlertoledo/icir_control.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from flowchem.components.analytics.ir import IRControl, IRSpectrum
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from .icir import IcIR
@@ -82,3 +83,8 @@ class IcIRControl(IRControl):
             bool: True if the experiment was successfully stopped, False otherwise.
         """
         return await self.hw_device.stop_experiment()
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the iCIR OPC UA connection to the instrument is active."""
+        connected = await self.hw_device.is_iCIR_connected()
+        return ReachabilityStatus.ONLINE if connected else ReachabilityStatus.OFFLINE

--- a/src/flowchem/devices/mettlertoledo/icir_finder.py
+++ b/src/flowchem/devices/mettlertoledo/icir_finder.py
@@ -1,7 +1,6 @@
 """Autodiscover iCIR opcua server locally."""
 
 import asyncio
-import sys
 from textwrap import dedent
 
 from loguru import logger
@@ -40,10 +39,6 @@ async def generate_icir_config() -> str:
 
 def icir_finder():
     """Attempt connection on local iCIR instance."""
-    # This is a bug of asyncio on Windows :|
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     try:
         return [asyncio.run(generate_icir_config())]
     except OSError:

--- a/src/flowchem/devices/ni/ni6519_component.py
+++ b/src/flowchem/devices/ni/ni6519_component.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.components.technical.MultiChannels import MultiChannelRelay
 
 if TYPE_CHECKING:
@@ -102,3 +103,11 @@ class NI6519DigitalInput(FlowchemComponent):
     async def read_all(self) -> list[int]:
         """Read all 16 digital input channels."""
         return [int(state) for state in await self.hw_device.read_input_channels()]
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the NI-6519 digital input task responds."""
+        try:
+            await self.read_all()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/devices/ni/nidaq_analog_io_component.py
+++ b/src/flowchem/devices/ni/nidaq_analog_io_component.py
@@ -9,6 +9,7 @@ from loguru import logger
 from pint.errors import DimensionalityError, UndefinedUnitError
 
 from flowchem import ureg
+from flowchem.components.reachability import ReachabilityStatus
 from flowchem.components.technical.MultiChannels import MultiChannelADC, MultiChannelDAC
 
 if TYPE_CHECKING:
@@ -28,6 +29,14 @@ class NIDAQAnalogInput(MultiChannelADC):
         """Read all configured analog input channels in volts."""
         return await self.hw_device.read_all_adc()
 
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the NI-DAQmx analog input task responds."""
+        try:
+            await self.read_all()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE
+
 
 class NIDAQAnalogOutput(MultiChannelDAC):
     """Multi-channel DAC component for NI-DAQmx analog outputs."""
@@ -37,6 +46,16 @@ class NIDAQAnalogOutput(MultiChannelDAC):
     async def read(self, channel: str) -> float:  # type: ignore[override]
         """Return the cached analog output setpoint in volts."""
         return self.hw_device.read_dac(channel)
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return OFFLINE if the NI-DAQmx analog output task failed to initialise, UNKNOWN otherwise.
+
+        The DAC task existing confirms initialisation succeeded, but there is no
+        live hardware probe to confirm the physical device is still responding.
+        """
+        if self.hw_device._dac_task is None:
+            return ReachabilityStatus.OFFLINE
+        return ReachabilityStatus.UNKNOWN
 
     async def set(self, channel: str = "1", value: str = "0 V") -> bool:  # type: ignore[override]
         """Set one analog output channel."""

--- a/src/flowchem/devices/trinamic/tmcm1111_component.py
+++ b/src/flowchem/devices/trinamic/tmcm1111_component.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flowchem.components.flowchem_component import FlowchemComponent
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from .tmcm1111 import TMCM1111
@@ -56,3 +57,11 @@ class TMCM1111FractionCollector(FlowchemComponent):
     async def target_reached(self) -> bool:
         """Return whether the target position has been reached."""
         return await self.hw_device.is_target_reached()
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Return ONLINE if the TMCM-1111 responds over serial."""
+        try:
+            await self.hw_device.get_actual_position()
+            return ReachabilityStatus.ONLINE
+        except Exception:
+            return ReachabilityStatus.OFFLINE

--- a/src/flowchem/devices/waters/waters_ms_component.py
+++ b/src/flowchem/devices/waters/waters_ms_component.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from flowchem.components.analytics.ms import MSControl
+from flowchem.components.reachability import ReachabilityStatus
 
 if TYPE_CHECKING:
     from flowchem.devices import WatersMS
@@ -54,6 +55,15 @@ class WatersMSControl(MSControl):
             tune_file=tune_file,
             inlet_method=inlet_method,
         )
+
+    async def is_reachable(self) -> ReachabilityStatus:
+        """Not implemented — WatersMS exposes no read-only status endpoint.
+
+        The WatersMS driver only provides set_method() and record_mass_spec(),
+        both of which are mutating operations. A safe connectivity probe is not
+        available without additional instrument support.
+        """
+        return ReachabilityStatus.UNKNOWN
 
     async def run_sample(
         self,

--- a/src/flowchem/server/fastapi_server.py
+++ b/src/flowchem/server/fastapi_server.py
@@ -1,11 +1,12 @@
 """FastAPI server for devices control."""
 
-from collections.abc import Iterable
+from collections.abc import AsyncIterator, Iterable
+from contextlib import asynccontextmanager
 from importlib.metadata import metadata, version
+from typing import Any
 
 from fastapi import APIRouter, FastAPI
 from loguru import logger
-from typing import Any
 from starlette.responses import RedirectResponse
 
 from flowchem.components.device_info import DeviceInfo
@@ -17,6 +18,14 @@ class FastAPIServer:
     def __init__(
         self, filename: str = "", host: str = "127.0.0.1", port: int = 8000
     ) -> None:
+        self._startup_tasks: list = []
+
+        @asynccontextmanager
+        async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+            for task in self._startup_tasks:
+                await task()
+            yield
+
         # Create FastAPI app
         self.app = FastAPI(
             title=f"Flowchem - {filename}",
@@ -26,6 +35,7 @@ class FastAPIServer:
                 "name": "MIT License",
                 "url": "https://opensource.org/licenses/MIT",
             },
+            lifespan=lifespan,
         )
         self.base_url = rf"http://{host}:{port}"
         self.configuration_dict: dict[str, Any] = {}
@@ -75,11 +85,12 @@ class FastAPIServer:
 
         for seconds_delay, task in repeated_tasks:
             # `t=task` captures the current task by value, not by reference.
-            @self.app.on_event("startup")
             @repeat_every(seconds=seconds_delay)
             async def _repeated_task(t=task):
                 logger.debug("Running repeated task...")
                 await t()
+
+            self._startup_tasks.append(_repeated_task)
 
     def add_device(self, device):
         """Add device to server."""

--- a/src/flowchem/server/zeroconf_server.py
+++ b/src/flowchem/server/zeroconf_server.py
@@ -2,13 +2,13 @@
 
 import uuid
 
+import ifaddr
 from loguru import logger
 from zeroconf import (
     IPVersion,
     NonUniqueNameException,
     ServiceInfo,
     Zeroconf,
-    get_all_addresses,
 )
 
 
@@ -22,10 +22,12 @@ class ZeroconfServer:
 
         # Get list of host addresses
         self.mdns_addresses = [
-            ip
-            for ip in get_all_addresses()  # Get all local IP
-            if ip not in ("127.0.0.1", "0.0.0.0")
-            and not ip.startswith("169.254")  # Remove invalid IPs
+            addr.ip
+            for adapter in ifaddr.get_adapters()
+            for addr in adapter.ips
+            if isinstance(addr.ip, str)
+            and addr.ip not in ("127.0.0.1", "0.0.0.0")
+            and not addr.ip.startswith("169.254")
         ]
         if not self.mdns_addresses:
             self.mdns_addresses.append("127.0.0.1")

--- a/src/flowchem/sim/__main__.py
+++ b/src/flowchem/sim/__main__.py
@@ -111,9 +111,6 @@ def main(device_config_file, logfile, host, debug):
     real device driver with its simulation counterpart.  No physical
     instruments need to be connected.
     """
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
     if not debug:
         logger.remove()
         logger.add(sys.stderr, level="INFO")

--- a/src/flowchem/sim/devices/hamilton/ml600_sim.py
+++ b/src/flowchem/sim/devices/hamilton/ml600_sim.py
@@ -296,8 +296,10 @@ class SimulatedHamiltonPumpIO(HamiltonPumpIO):
             return _ack(state.firmware_version)
 
         # BUSY_STATUS: "T1"  → all-idle bit pattern.
+        # "?" = 0x3F = 0b00111111; reversed = "11111100".
+        # system_status checks all_status[i] == "0" for busy; bits 0-5 are "1" → idle.
         if "T1" in cmd_body:
-            return _ack("@")
+            return _ack("?")
 
         # STATUS_REQUEST: "E1"  → no errors, all bits clear
         if "E1" in cmd_body:

--- a/src/flowchem/sim/devices/knauer/autosampler_sim.py
+++ b/src/flowchem/sim/devices/knauer/autosampler_sim.py
@@ -192,3 +192,15 @@ class KnauerAutosamplerSim(FlowchemDevice):
 
     async def measure_tray_temperature(self) -> int:
         return self._sim_tray_temp_sp
+
+    async def set_tray_temperature_control(self, onoff: str = "on") -> bool:
+        logger.debug(f"[SIM] Tray temperature control → {onoff}")
+        return True
+
+    async def compressor(self, onoff: str = "on") -> bool:
+        logger.debug(f"[SIM] Compressor → {onoff}")
+        return True
+
+    async def set_needle_vertical_offset(self, offset: float = 2.0) -> bool:
+        logger.debug(f"[SIM] Needle vertical offset → {offset} mm")
+        return True

--- a/src/flowchem/sim/devices/waters/waters_sim.py
+++ b/src/flowchem/sim/devices/waters/waters_sim.py
@@ -77,5 +77,6 @@ class WatersMSSim(WatersMS):
         file_path = self.queue_path / Path(queue_name)
         with open(file_path, "w") as f:
             f.write(self.fields)
-            f.write(f"\n{sample_name}{self.rows}")
+            f.write(f"\n{self._build_queue_row(sample_name)}")
         # Skip do_conversion — never invoke subprocess in simulation.
+        return True

--- a/src/flowchem/vendor/repeat_every.py
+++ b/src/flowchem/vendor/repeat_every.py
@@ -1,6 +1,7 @@
 """Vendored from fastapi_utils due to the package incompatibility with pydantic v2"""
 
 import asyncio
+import inspect
 import logging
 from asyncio import ensure_future
 from collections.abc import Callable, Coroutine
@@ -53,7 +54,7 @@ def repeat_every(
         func: NoArgsNoReturnAsyncFuncT | NoArgsNoReturnFuncT,
     ) -> NoArgsNoReturnAsyncFuncT:
         """Convert the decorated function into a repeated, periodically-called version of itself."""
-        is_coroutine = asyncio.iscoroutinefunction(func)
+        is_coroutine = inspect.iscoroutinefunction(func)
 
         @wraps(func)
         async def wrapped() -> None:

--- a/tests/devices/pumps/test_azura_compact.py
+++ b/tests/devices/pumps/test_azura_compact.py
@@ -2,30 +2,13 @@
 Run with python -m pytest ./tests -m KPump and updates pump address below.
 """
 
-import asyncio
 import math
-import sys
 
 import pint
 import pytest
 
 from flowchem import ureg
 from flowchem.devices.knauer.azura_compact import AzuraCompact, AzuraPumpHeads
-
-if sys.platform == "win32":
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
-
-# noinspection PyUnusedLocal
-@pytest.fixture(scope="session")
-def event_loop(request):
-    """Args:
-    ----
-        request:
-    """
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
 
 
 @pytest.fixture(scope="session")

--- a/tests/server/test_fastapi_server.py
+++ b/tests/server/test_fastapi_server.py
@@ -11,7 +11,7 @@ def test_add_background_tasks_accepts_single_repeated_task():
 
     server.add_background_tasks(RepeatedTaskInfo(seconds_every=5, task=_noop))
 
-    assert len(server.app.router.on_startup) == 1
+    assert len(server._startup_tasks) == 1
 
 
 def test_add_background_tasks_accepts_multiple_repeated_tasks():
@@ -23,4 +23,4 @@ def test_add_background_tasks_accepts_multiple_repeated_tasks():
 
     server.add_background_tasks(tasks)
 
-    assert len(server.app.router.on_startup) == 2
+    assert len(server._startup_tasks) == 2

--- a/tests/sim/conftest.py
+++ b/tests/sim/conftest.py
@@ -1,11 +1,1 @@
 """Shared fixtures for all sim tests."""
-
-import pytest
-
-
-@pytest.fixture(scope="session")
-def event_loop_policy():
-    """Use the default event loop policy for all sim tests."""
-    import asyncio
-
-    return asyncio.DefaultEventLoopPolicy()

--- a/tests/sim/hamilton/test_ml600.py
+++ b/tests/sim/hamilton/test_ml600.py
@@ -479,8 +479,9 @@ class TestSimulatedIO:
         """BUSY_STATUS should always return the idle bit pattern in simulation."""
         io = SimulatedHamiltonPumpIO(num_pumps=1)
         response = io._dispatch("aT1R\r", pump_num=1)
-        # '@' = 0x40; when reversed its bit pattern has all busy bits = 0 (idle).
-        assert chr(6) + "@" in response
+        # '?' = 0x3F = 0b00111111; reversed = "11111100".
+        # system_status checks all_status[i] == "0" for busy; bits 0-5 are "1" → idle.
+        assert chr(6) + "?" in response
 
     def test_dispatch_init_syringe_resets_position(self):
         """INIT_SYRINGE_ONLY should set syringe_position to 0."""

--- a/tests/sim/test_sim_server.py
+++ b/tests/sim/test_sim_server.py
@@ -42,6 +42,8 @@ SAMPLE_QUERY_VALUES: dict[str, object] = {
     "method-name": "smoke-method",
     "method_name": "smoke-method",
     "mode": "fast",
+    "offset": 2.0,
+    "onoff": "on",
     "output_dir": "PATH/TO/open_format_ms",
     "position": "1",
     "pressure": "1 bar",


### PR DESCRIPTION
Add the is-reachable end-points to the components (useful to inspect if the device is online)
Remove Python 3.12–3.14 deprecation warnings that would become errors in future Python versions
Fix failing and freezing tests in the Hamilton ML600 and Waters MS simulators
Fix missing methods in the Knauer Autosampler simulator