### PR TITLE
Add Ocean Optics spectrometer support

### DIFF
--- a/src/flowchem/devices/__init__.py
+++ b/src/flowchem/devices/__init__.py
@@ -12,6 +12,7 @@ from .magritek import *
 from .manson import *
 from .mettlertoledo import *
 from .ni import *
+from .oceanoptics import *
 from .phidgets import *
 from .trinamic import *
 from .vacuubrand import *

--- a/src/flowchem/devices/oceanoptics/__init__.py
+++ b/src/flowchem/devices/oceanoptics/__init__.py
@@ -1,0 +1,6 @@
+try:
+    from .flame import FlameOptical
+except ImportError:
+    __all__: list[str] = []
+else:
+    __all__ = ["FlameOptical"]

--- a/src/flowchem/devices/oceanoptics/flame.py
+++ b/src/flowchem/devices/oceanoptics/flame.py
@@ -1,0 +1,187 @@
+"""
+Ocean Optics / Ocean Insight spectrometer support.
+
+Windows note:
+- pyseabreeze needs libusb available on the DLL search path
+- OceanView often locks the device, causing an access denied error here
+"""
+
+import os
+import platform
+import sys
+import sysconfig
+
+import numpy as np
+import seabreeze
+from loguru import logger
+
+from flowchem.devices.flowchem_device import FlowchemDevice
+from flowchem.devices.oceanoptics.flame_spectrometer import GeneralSensor
+from flowchem.utils.people import wei_hsin
+
+
+def _configure_libusb_for_windows() -> None:
+    """Expose the libusb wheel DLL to pyusb on Windows."""
+    if sys.platform != "win32":
+        return
+
+    arch = "x86_64" if platform.machine().lower() in {"amd64", "x86_64"} else "x86"
+    libusb_dir = (
+        sysconfig.get_paths()["purelib"],
+        "libusb",
+        "_platform",
+        "windows",
+        arch,
+    )
+    libusb_path = os.path.join(*libusb_dir)
+    if not os.path.isdir(libusb_path):
+        return
+
+    if hasattr(os, "add_dll_directory"):
+        os.add_dll_directory(libusb_path)
+    os.environ["PATH"] = f"{libusb_path}{os.pathsep}{os.environ.get('PATH', '')}"
+
+
+def _candidate_backends(requested: str | None) -> list[str]:
+    env_backend = os.getenv("FLOWCHEM_OCEANOPTICS_BACKEND", "").strip().lower()
+    backend = (requested or env_backend or "auto").strip().lower()
+
+    if backend in {"cseabreeze", "pyseabreeze"}:
+        return [backend]
+
+    if sys.platform == "win32":
+        return ["pyseabreeze", "cseabreeze"]
+
+    return ["cseabreeze", "pyseabreeze"]
+
+
+def _select_backend(requested: str | None) -> str:
+    last_error: Exception | None = None
+    _configure_libusb_for_windows()
+
+    for backend_name in _candidate_backends(requested):
+        try:
+            seabreeze.use(backend_name)
+            logger.info(f"Ocean Optics seabreeze backend selected: {backend_name}")
+            return backend_name
+        except Exception as exc:  # pragma: no cover - environment-specific
+            last_error = exc
+            logger.warning(f"Failed to activate seabreeze backend '{backend_name}': {exc}")
+
+    raise RuntimeError(
+        "No usable seabreeze backend found for Ocean Optics. "
+        "Set FLOWCHEM_OCEANOPTICS_BACKEND to 'pyseabreeze' or 'cseabreeze'."
+    ) from last_error
+
+
+def _normalize_open_error(exc: Exception) -> Exception:
+    message = str(exc).lower()
+    if "access denied" in message or "insufficient permissions" in message:
+        return RuntimeError(
+            "Ocean Optics USB access denied. Close OceanView or any other software using the "
+            "spectrometer, reconnect the device, and rerun from an Administrator terminal."
+        )
+    return exc
+
+
+class FlameOptical(FlowchemDevice):
+    def __init__(
+        self,
+        serial_number: str | None = None,
+        backend: str | None = None,
+        name: str = "",
+    ) -> None:
+        self.serial_n = serial_number
+        self.backend = _select_backend(backend)
+        self.scans_to_average = 1
+        self.trigger_mode_value: int | None = None
+        super().__init__(name)
+
+        self.device_info.authors = [wei_hsin]
+        self.device_info.manufacturer = "oceanoptics"
+        self.device_info.model = "python-seabreeze"
+        self.device_info.additional_info["seabreeze_backend"] = self.backend
+
+        from seabreeze.spectrometers import Spectrometer
+
+        try:
+            if self.serial_n is None:
+                self.spectrometer = Spectrometer.from_first_available()
+            else:
+                self.spectrometer = Spectrometer.from_serial_number(self.serial_n)
+        except Exception as exc:
+            raise _normalize_open_error(exc) from exc
+
+        self.model: str = self.spectrometer.model
+        self.max_intensity: float = self.spectrometer.max_intensity
+        self.pixels: int = self.spectrometer.pixels
+        self.integration_time_micros_limits: tuple = self.spectrometer.integration_time_micros_limits
+        self.wavelengths = self.spectrometer.wavelengths()
+
+    async def initialize(self):
+        self.components.append(GeneralSensor("spectrometer", self))
+
+    async def power_on(self):
+        self.spectrometer.open()
+
+    async def power_off(self):
+        self.spectrometer.close()
+
+    async def get_spectrum(self):
+        return self.spectrometer.spectrum()
+
+    def _effective_scans_to_average(self, scans_to_average: int | None = None) -> int:
+        scans = self.scans_to_average if scans_to_average is None else scans_to_average
+        if scans < 1:
+            raise ValueError("scans_to_average must be >= 1")
+        return scans
+
+    def _read_raw_intensities(self, scans_to_average: int | None = None) -> list[float]:
+        scans = self._effective_scans_to_average(scans_to_average)
+        if scans == 1:
+            return self.spectrometer.intensities().tolist()
+
+        samples = [self.spectrometer.intensities() for _ in range(scans)]
+        return np.mean(samples, axis=0).tolist()
+
+    async def get_intensity(self, absolute: bool = False, scans_to_average: int | None = None):
+        intensities = self._read_raw_intensities(scans_to_average)
+        if absolute:
+            return intensities
+        return [value / self.max_intensity for value in intensities]
+
+    async def get_wavelength(self):
+        return self.wavelengths.tolist()
+
+    async def integration_time(self, int_time: int):
+        low, high = self.integration_time_micros_limits
+        if low <= int_time <= high:
+            self.spectrometer.integration_time_micros(int_time)
+        elif int_time < low:
+            logger.warning("Requested integration time below device limit; using minimum value instead.")
+            self.spectrometer.integration_time_micros(low)
+        else:
+            logger.warning("Requested integration time above device limit; using maximum value instead.")
+            self.spectrometer.integration_time_micros(high)
+
+    async def set_scans_to_average(self, scans: int):
+        scans = int(scans)
+        if scans < 1:
+            raise ValueError("scans_to_average must be >= 1")
+        self.scans_to_average = scans
+        return self.scans_to_average
+
+    async def get_scans_to_average(self):
+        return self.scans_to_average
+
+    async def set_trigger_mode(self, mode: int):
+        mode = int(mode)
+        try:
+            self.spectrometer.trigger_mode(mode)
+        except AttributeError as exc:
+            raise RuntimeError("This Ocean Optics device/backend does not support trigger mode control.") from exc
+        self.trigger_mode_value = mode
+        return self.trigger_mode_value
+
+    async def get_trigger_mode(self):
+        return self.trigger_mode_value

--- a/src/flowchem/devices/oceanoptics/flame_spectrometer.py
+++ b/src/flowchem/devices/oceanoptics/flame_spectrometer.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING
+
+from flowchem.components.sensors.photo_sensor import PhotoSensor
+from flowchem.devices.flowchem_device import FlowchemDevice
+
+if TYPE_CHECKING:
+    from flowchem.devices.oceanoptics.flame import FlameOptical
+
+
+class GeneralSensor(PhotoSensor):
+    def __init__(self, name: str, hw_device: FlowchemDevice) -> None:
+        super().__init__(name, hw_device)
+        self.add_api_route("/get-wavelength", self.get_wavelength, methods=["GET"])
+        self.add_api_route("/set-integration-time", self.set_integration_time, methods=["PUT"])
+        self.add_api_route("/get-scans-to-average", self.get_scans_to_average, methods=["GET"])
+        self.add_api_route("/set-scans-to-average", self.set_scans_to_average, methods=["PUT"])
+        self.add_api_route("/get-trigger-mode", self.get_trigger_mode, methods=["GET"])
+        self.add_api_route("/set-trigger-mode", self.set_trigger_mode, methods=["PUT"])
+
+    async def acquire_signal(self, absolute: bool = True) -> list:
+        return await self.hw_device.get_intensity(
+            absolute=absolute,
+            scans_to_average=getattr(self.hw_device, "scans_to_average", 1),
+        )
+
+    async def get_wavelength(self) -> list:
+        return await self.hw_device.get_wavelength()
+
+    async def set_integration_time(self, int_time: int):
+        return await self.hw_device.integration_time(int_time)
+
+    async def get_scans_to_average(self):
+        return await self.hw_device.get_scans_to_average()
+
+    async def set_scans_to_average(self, scans: int):
+        return await self.hw_device.set_scans_to_average(scans)
+
+    async def get_trigger_mode(self):
+        return await self.hw_device.get_trigger_mode()
+
+    async def set_trigger_mode(self, mode: int):
+        return await self.hw_device.set_trigger_mode(mode)
+
+    async def power_on(self) -> str:
+        return await self.hw_device.power_on()
+
+    async def power_off(self) -> str:
+        return await self.hw_device.power_off()


### PR DESCRIPTION
## Summary

This PR adds Ocean Optics / Ocean Insight spectrometer support to `flowchem`.

## Changes

- add a new `flowchem.devices.oceanoptics` module
- add `FlameOptical` support for Ocean Optics spectrometers
- expose Ocean Optics devices through `flowchem.devices`
- add Windows compatibility for `pyseabreeze` by configuring the `libusb` DLL path
- improve backend selection for Ocean Optics devices on Windows
- add clearer error handling for USB access conflicts, such as OceanView locking the device
- add support for:
  - integration time
  - trigger mode
  - scans to average
  - wavelength retrieval
  - intensity acquisition
  - spectrum acquisition

## Validation

Tested locally with an OceanSR4 spectrometer using `pyseabreeze`.

Verified:
- device detection
- device connection
- wavelength acquisition
- intensity acquisition
- spectrum acquisition
- integration time setting
- trigger mode setting
- scans-to-average setting