### PR TITLE
Summary of what's on the branch

### DIFF
--- a/src/flowchem/components/pumps/pump.py
+++ b/src/flowchem/components/pumps/pump.py
@@ -12,6 +12,7 @@ class Pump(FlowchemComponent):
         self.add_api_route("/infuse", self.infuse, methods=["PUT"])
         self.add_api_route("/stop", self.stop, methods=["PUT"])
         self.add_api_route("/is-pumping", self.is_pumping, methods=["GET"])
+        self.add_api_route("/flowrate", self.get_flowrate, methods=["GET"])
         if self.is_withdrawing_capable():
             self.add_api_route("/withdraw", self.withdraw, methods=["PUT"])
         self.component_info.type = "Pump"
@@ -26,6 +27,13 @@ class Pump(FlowchemComponent):
 
     async def is_pumping(self) -> bool:
         """Is pump running?"""
+        raise NotImplementedError
+
+    async def get_flowrate(self) -> float:
+        """Return the pump's current flow rate in ml/min.
+
+        Positive while infusing, negative while withdrawing, 0 when idle.
+        """
         raise NotImplementedError
 
     @staticmethod

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -351,6 +351,8 @@ class ML600(FlowchemDevice):
         syringe_volume: str,
         name: str,
         address: int = 1,
+        left_syringe_volume: str = "",
+        right_syringe_volume: str = "",
         **config,
     ) -> None:
         """Default constructor, needs an HamiltonPumpIO object. See from_config() for config-based init."""
@@ -364,8 +366,24 @@ class ML600(FlowchemDevice):
         ML600._io_instances.add(self.pump_io)
         self.address = int(address)
 
+        # The left ("B") and right ("C") drives can carry differently sized
+        # syringes; each side falls back to the shared syringe_volume when not
+        # given its own value.
+        self._syringe_volume: dict[str, pint.Quantity] = {
+            "B": self._validate_syringe_volume(left_syringe_volume or syringe_volume),
+            "C": self._validate_syringe_volume(right_syringe_volume or syringe_volume),
+        }
+        self._steps_per_ml: dict[str, pint.Quantity] = {
+            code: ureg.Quantity(f"{48000 / volume} step")
+            for code, volume in self._syringe_volume.items()
+        }
+        self.inspect_valve_argument(config)
+        self.dual_syringe = False
+
+    def _validate_syringe_volume(self, syringe_volume: str) -> pint.Quantity:
+        """Parse a syringe volume string and check it against the valid sizes."""
         try:
-            self.syringe_volume: pint.Quantity = ureg.Quantity(syringe_volume)
+            volume = ureg.Quantity(syringe_volume)
         except AttributeError as attribute_error:
             logger.error(f"Invalid syringe volume {syringe_volume}!")
             raise InvalidConfigurationError(
@@ -373,16 +391,20 @@ class ML600(FlowchemDevice):
                 "The syringe volume is a string with units, e.g. '5 ml'."
             ) from attribute_error
 
-        if self.syringe_volume.m_as("ml") not in ML600.VALID_SYRINGE_VOLUME:
+        if volume.m_as("ml") not in ML600.VALID_SYRINGE_VOLUME:
             raise InvalidConfigurationError(
                 f"The specified syringe volume ({syringe_volume}) is invalid!\n"
                 f"The volume (in ml) has to be one of {ML600.VALID_SYRINGE_VOLUME}"
             )
-        self._steps_per_ml: pint.Quantity = ureg.Quantity(
-            f"{48000 / self.syringe_volume} step"
-        )
-        self.inspect_valve_argument(config)
-        self.dual_syringe = False
+        return volume
+
+    def syringe_volume(self, pump: str = "") -> pint.Quantity:
+        """Syringe volume of the given drive ('B' left/single, 'C' right)."""
+        return self._syringe_volume[pump or "B"]
+
+    def _steps_per_ml_for(self, pump: str = "") -> pint.Quantity:
+        """Step-per-ml conversion factor of the given drive."""
+        return self._steps_per_ml[pump or "B"]
 
     def inspect_valve_argument(self, config: dict):
         if config.get("left_valve") and config.get("left_valve") not in ValveType:
@@ -410,13 +432,22 @@ class ML600(FlowchemDevice):
                 k: v
                 for k, v in config.items()
                 if k
-                not in ("syringe_volume", "address", "name", *cls.DEFAULT_CONFIG.keys())
+                not in (
+                    "syringe_volume",
+                    "left_syringe_volume",
+                    "right_syringe_volume",
+                    "address",
+                    "name",
+                    *cls.DEFAULT_CONFIG.keys(),
+                )
             }
             pumpio = HamiltonPumpIO.from_config(config_for_pumpio)
         configuration = {k: config[k] for k in cls.DEFAULT_CONFIG.keys() if k in config}
         return cls(
             pumpio,
             syringe_volume=config.get("syringe_volume", ""),
+            left_syringe_volume=config.get("left_syringe_volume", ""),
+            right_syringe_volume=config.get("right_syringe_volume", ""),
             address=config.get("address", 1),
             name=config.get("name", ""),
             **configuration,
@@ -526,21 +557,23 @@ class ML600(FlowchemDevice):
         )
         return await self.send_command_and_read_reply(init_syringe)
 
-    def _flowrate_to_seconds_per_stroke(self, flowrate: pint.Quantity) -> pint.Quantity:
+    def _flowrate_to_seconds_per_stroke(
+        self, flowrate: pint.Quantity, pump: str = ""
+    ) -> pint.Quantity:
         """Convert flow rate to seconds per stroke."""
-        flowrate_in_steps_sec = flowrate * self._steps_per_ml
+        flowrate_in_steps_sec = flowrate * self._steps_per_ml_for(pump)
         return (1 / flowrate_in_steps_sec).to("second/stroke")
 
     def _seconds_per_stroke_to_flowrate(
-        self, second_per_stroke: pint.Quantity
+        self, second_per_stroke: pint.Quantity, pump: str = ""
     ) -> pint.Quantity:
         """Convert seconds per stroke to flow rate."""
-        flowrate = 1 / (second_per_stroke * self._steps_per_ml)
+        flowrate = 1 / (second_per_stroke * self._steps_per_ml_for(pump))
         return flowrate.to("ml/min")
 
-    def _volume_to_step_position(self, volume: pint.Quantity) -> int:
+    def _volume_to_step_position(self, volume: pint.Quantity, pump: str = "") -> int:
         """Convert a volume to a step position."""
-        steps = volume * self._steps_per_ml
+        steps = volume * self._steps_per_ml_for(pump)
         return round(steps.m_as("steps"))
 
     async def get_current_volume(self, pump: str = "") -> pint.Quantity:
@@ -551,15 +584,15 @@ class ML600(FlowchemDevice):
             )
         )
         current_steps = int(syringe_pos) * ureg.step
-        return current_steps / self._steps_per_ml
+        return current_steps / self._steps_per_ml_for(pump)
 
     async def set_to_volume(
         self, target_volume: pint.Quantity, rate: pint.Quantity, pump: str = ""
     ):
         """Absolute move to target volume at the given rate."""
-        speed = self._flowrate_to_seconds_per_stroke(rate)
+        speed = self._flowrate_to_seconds_per_stroke(rate, pump)
         set_speed = self._validate_speed(speed)
-        position = self._volume_to_step_position(target_volume)
+        position = self._volume_to_step_position(target_volume, pump)
         logger.debug(
             f"Pump {self.name} set to volume {target_volume} at speed {set_speed}"
         )
@@ -865,12 +898,13 @@ class ML600(FlowchemDevice):
             )
 
         set_speed_right = self._validate_speed(
-            self._flowrate_to_seconds_per_stroke(rate_right)
+            self._flowrate_to_seconds_per_stroke(rate_right, "C")
         )
         set_speed_left = self._validate_speed(
-            self._flowrate_to_seconds_per_stroke(rate_left)
+            self._flowrate_to_seconds_per_stroke(rate_left, "B")
         )
-        position = self._volume_to_step_position(target_volume)
+        position_left = self._volume_to_step_position(target_volume, "B")
+        position_right = self._volume_to_step_position(target_volume, "C")
         logger.debug(
             f"Pumps {self.name} set to volume {target_volume} at speeds left: {set_speed_left}, right: {set_speed_right}"
         )
@@ -896,14 +930,14 @@ class ML600(FlowchemDevice):
                 Protocol1Command(
                     command=ML600Commands.ABSOLUTE_MOVE,
                     optional_parameter="S",
-                    command_value=str(position),
+                    command_value=str(position_left),
                     parameter_value=set_speed_left,
                     target_component="B",
                 ),
                 Protocol1Command(
                     command=ML600Commands.ABSOLUTE_MOVE,
                     optional_parameter="S",
-                    command_value=str(position),
+                    command_value=str(position_right),
                     parameter_value=set_speed_right,
                     target_component="C",
                 ),

--- a/src/flowchem/devices/hamilton/ml600.py
+++ b/src/flowchem/devices/hamilton/ml600.py
@@ -383,7 +383,7 @@ class ML600(FlowchemDevice):
     def _validate_syringe_volume(self, syringe_volume: str) -> pint.Quantity:
         """Parse a syringe volume string and check it against the valid sizes."""
         try:
-            volume = ureg.Quantity(syringe_volume)
+            volume: pint.Quantity = ureg.Quantity(syringe_volume)
         except AttributeError as attribute_error:
             logger.error(f"Invalid syringe volume {syringe_volume}!")
             raise InvalidConfigurationError(

--- a/src/flowchem/devices/hamilton/ml600_pump.py
+++ b/src/flowchem/devices/hamilton/ml600_pump.py
@@ -51,6 +51,10 @@ class ML600Pump(SyringePump):
         self.pump_code = pump_code
         # self.add_api_route("/pump", self.get_monitor_position, methods=["GET"])
 
+        # Signed ml/min from the last infuse()/withdraw() issued via this driver.
+        # Used by get_flowrate(from_hardware=False), see there for why this exists.
+        self._last_signed_rate: float = 0.0
+
     @staticmethod
     def is_withdrawing_capable() -> bool:
         """
@@ -80,6 +84,7 @@ class ML600Pump(SyringePump):
             True if the pump successfully stops, False otherwise.
         """
         await self.hw_device.stop(self.pump_code)
+        self._last_signed_rate = 0.0
         # todo: sometime it take more then two seconds.
         await asyncio.sleep(1)
         if not await self.hw_device.get_pump_status(self.pump_code):
@@ -88,6 +93,39 @@ class ML600Pump(SyringePump):
             logger.warning("the first check show false. try again.")
             await asyncio.sleep(1)
             return not await self.hw_device.get_pump_status(self.pump_code)
+
+    async def get_flowrate(
+        self, from_hardware: bool = False, sample_interval: str = "0.2 s"
+    ) -> float:
+        """Return the pump's current flow rate in ml/min (+infusing / -withdrawing).
+
+        Hamilton's Protocol1/RNO+ command set has no live-speed register for the ML600:
+        the only speed-related query (YQS) reports the configured default speed, not the
+        speed of an in-progress move, and there is no motor tachometer feedback. So there
+        are two ways to answer "what's the flow rate right now", selected by `from_hardware`:
+
+        - False (default, "soft" tracking): report the rate/direction from the last
+          infuse()/withdraw() call issued through this driver, 0 once stop() was called
+          or the pump reports idle. Instant and stable, but not verified against the
+          pump itself - it will be wrong if the syringe was driven by another controller,
+          if the move already completed on its own (target volume reached), or after a stall.
+        - True (hardware sampling): sample the real syringe position (YQP) twice,
+          `sample_interval` apart, and derive ml/min (and sign) from the actual volume
+          change. This is grounded in hardware, but takes ~`sample_interval` seconds per
+          call and is noisier at low flow rates or short intervals.
+        """
+        if not from_hardware:
+            return self._last_signed_rate if await self.is_pumping() else 0.0
+
+        interval: pint.Quantity = ureg.Quantity(sample_interval)
+        volume_before = await self.hw_device.get_current_volume(self.pump_code)
+        await asyncio.sleep(interval.m_as("s"))
+        volume_after = await self.hw_device.get_current_volume(self.pump_code)
+
+        # Syringe volume decreases while infusing (dispensing) and increases while
+        # withdrawing (drawing in), so this difference is already correctly signed.
+        delta_ml = (volume_before - volume_after).m_as("ml")
+        return delta_ml / interval.m_as("min")
 
     async def infuse(self, rate: str = "1 ml/min", volume: str = "") -> bool:
         """Start infusion with given rate and volume (both optional).
@@ -137,6 +175,7 @@ class ML600Pump(SyringePump):
         await self.hw_device.set_to_volume(
             target_vol, ureg.Quantity(rate), self.pump_code
         )
+        self._last_signed_rate = ureg.Quantity(rate).m_as("ml/min")
         logger.info(
             f"infusing is run. it will take {effective_volume / ureg.Quantity(rate)} to finish."
         )
@@ -189,6 +228,7 @@ class ML600Pump(SyringePump):
         await self.hw_device.set_to_volume(
             target_vol, ureg.Quantity(rate), self.pump_code
         )
+        self._last_signed_rate = -ureg.Quantity(rate).m_as("ml/min")
         logger.info(
             "withdrawing is run. it will take "
             f"{ureg.Quantity(volume if volume else syringe_volume) / ureg.Quantity(rate)} to finish."

--- a/src/flowchem/devices/hamilton/ml600_pump.py
+++ b/src/flowchem/devices/hamilton/ml600_pump.py
@@ -170,18 +170,19 @@ class ML600Pump(SyringePump):
         if not rate:
             rate = cast(str, self.hw_device.config["default_withdraw_rate"])
             logger.warning(f"the flow rate is not provided. set to the default {rate}")
+        syringe_volume = self.hw_device.syringe_volume(self.pump_code)
         if volume is None:
-            target_vol = self.hw_device.syringe_volume
+            target_vol = syringe_volume
             logger.warning(
-                f"the volume to withdraw is not provided. set to {self.hw_device.syringe_volume}"
+                f"the volume to withdraw is not provided. set to {syringe_volume}"
             )
         else:
             current_volume = await self.hw_device.get_current_volume(self.pump_code)
             target_vol = current_volume + ureg.Quantity(volume)
-            if target_vol > self.hw_device.syringe_volume:
+            if target_vol > syringe_volume:
                 logger.error(
                     f"Cannot withdraw target volume {volume}! "
-                    f"Max volume left is {self.hw_device.syringe_volume - current_volume}!",
+                    f"Max volume left is {syringe_volume - current_volume}!",
                 )
                 return False
 
@@ -190,7 +191,7 @@ class ML600Pump(SyringePump):
         )
         logger.info(
             "withdrawing is run. it will take "
-            f"{ureg.Quantity(volume if volume else self.hw_device.syringe_volume) / ureg.Quantity(rate)} to finish."
+            f"{ureg.Quantity(volume if volume else syringe_volume) / ureg.Quantity(rate)} to finish."
         )
         return await self.hw_device.get_pump_status(self.pump_code)
 
@@ -210,7 +211,9 @@ class ML600Pump(SyringePump):
         Initialize syringe on specified side only
         flowrate: ml/min
         """
-        speed = self.hw_device._flowrate_to_seconds_per_stroke(ureg.Quantity(rate))
+        speed = self.hw_device._flowrate_to_seconds_per_stroke(
+            ureg.Quantity(rate), self.pump_code
+        )
         return await self.hw_device.initialize_syringe(
             speed=ureg.Quantity(speed), pump=self.pump_code
         )

--- a/src/flowchem/devices/harvardapparatus/elite11.py
+++ b/src/flowchem/devices/harvardapparatus/elite11.py
@@ -360,6 +360,29 @@ class Elite11(FlowchemDevice):
             parameter=f"{set_rate:.10f} m/m",
         )
 
+    async def get_current_flow_rate(self) -> float:
+        """Return the rate the motor is actually running at right now, in ml/min.
+
+        Queries "crate", which the manufacturer's manual documents as returning a valid
+        reply only in dynamic situations (i.e. while the pump is moving), with the reply
+        stating the direction, e.g. "Infusing at 1.000 ml/min" or "Withdrawing at 0.500 ml/min".
+        This is a genuine hardware readback of the currently active rate, unlike
+        `get_flow_rate()`/`get_withdrawing_flow_rate()` which only report the configured
+        setpoints for infuse/withdraw respectively.
+
+        Returns 0 if the pump is idle, positive while infusing, negative while withdrawing.
+        """
+        if not await self.is_moving():
+            return 0.0
+
+        reply = await self._send_command_and_read_reply("crate")
+        direction, _, value_str = reply.partition(" at ")
+        flowrate = ureg.Quantity(value_str)
+        signed_rate = flowrate.m_as("ml/min")
+        if direction.strip().lower().startswith("withdraw"):
+            signed_rate = -signed_rate
+        return signed_rate
+
     async def get_withdrawing_flow_rate(self) -> float:
         """Return the withdrawing flow rate as ml/min."""
         flow_value = await self._send_command_and_read_reply("wrate")

--- a/src/flowchem/devices/harvardapparatus/elite11_pump.py
+++ b/src/flowchem/devices/harvardapparatus/elite11_pump.py
@@ -44,6 +44,14 @@ class Elite11PumpOnly(SyringePump):
         """Stop pump."""
         await self.hw_device.stop()
 
+    async def get_flowrate(self) -> float:
+        """Return the rate the pump is actually running at, in ml/min.
+
+        Queries the pump directly (CRATE). Positive while infusing, negative while
+        withdrawing (on models capable of it), 0 when idle.
+        """
+        return await self.hw_device.get_current_flow_rate()
+
     async def infuse(self, rate: str = "", volume: str = "0 ml") -> bool:
         """
         Infuse at the specified rate and volume.

--- a/src/flowchem/devices/knauer/_common.py
+++ b/src/flowchem/devices/knauer/_common.py
@@ -14,6 +14,7 @@ class KnauerEthernetDevice:
 
     TCP_PORT = 10001
     BUFFER_SIZE = 1024
+    TIMEOUT = 3.0
     _id_counter = 0
 
     def __init__(self, ip_address, mac_address, network="", **kwargs):
@@ -29,7 +30,10 @@ class KnauerEthernetDevice:
             ip_address: device IP address (only 1 of either IP or MAC address is needed)
             mac_address: device MAC address (only 1 of either IP or MAC address is needed)
             name: name of device (optional)
+            persistent_connection: keep a single long-lived TCP connection open
+                (default) rather than opening/closing a fresh one per command.
         """
+        self.persistent_connection = kwargs.pop("persistent_connection", True)
         super().__init__(**kwargs)
 
         # MAC address
@@ -38,7 +42,7 @@ class KnauerEthernetDevice:
         else:
             self.ip_address = ip_address
 
-        # These will be set in initialize()
+        # These will be set in initialize() when persistent_connection is True
         self._reader: asyncio.StreamReader = None  # type: ignore
         self._writer: asyncio.StreamWriter = None  # type: ignore
 
@@ -63,11 +67,17 @@ class KnauerEthernetDevice:
         return ip_address
 
     async def initialize(self):
-        """Initialize connection."""
-        # Future used to set shorter timeout than default
-        future = asyncio.open_connection(host=self.ip_address, port=10001)
+        """Initialize connection.
+
+        When persistent_connection is False, no long-lived reader/writer is
+        kept around -- only connectivity is probed here, and each command
+        opens/closes its own connection in ``_send_and_receive``.
+        """
         try:
-            self._reader, self._writer = await asyncio.wait_for(future, timeout=3)
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(host=self.ip_address, port=self.TCP_PORT),
+                timeout=self.TIMEOUT,
+            )
         except OSError as connection_error:
             logger.exception(connection_error)
             raise InvalidConfigurationError(
@@ -79,11 +89,41 @@ class KnauerEthernetDevice:
                 f"No reply from device {self.__class__.__name__} at IP={self.ip_address}"
             ) from timeout_error
 
+        if self.persistent_connection:
+            self._reader, self._writer = reader, writer
+        else:
+            writer.close()
+
     async def _send_and_receive(self, message: str) -> str:
+        if not self.persistent_connection:
+            return await self._send_and_receive_oneshot(message)
+
         async with self._lock:
             self._writer.write(message.encode("ascii") + self.eol)
             await self._writer.drain()
             logger.debug(f"WRITE >>> '{message}' ")
             reply = await self._reader.readuntil(separator=b"\r")
+        logger.debug(f"READ <<< '{reply.decode().strip()}' ")
+        return reply.decode("ascii").strip()
+
+    async def _send_and_receive_oneshot(self, message: str) -> str:
+        """Open a fresh connection, send ``message``, read the reply, then close.
+
+        Used when persistent_connection is False, for devices whose long-lived
+        socket is prone to going stale over the course of an experiment.
+        """
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host=self.ip_address, port=self.TCP_PORT),
+            timeout=self.TIMEOUT,
+        )
+        try:
+            writer.write(message.encode("ascii") + self.eol)
+            await writer.drain()
+            logger.debug(f"WRITE >>> '{message}' ")
+            reply = await asyncio.wait_for(
+                reader.readuntil(separator=b"\r"), timeout=self.TIMEOUT
+            )
+        finally:
+            writer.close()
         logger.debug(f"READ <<< '{reply.decode().strip()}' ")
         return reply.decode("ascii").strip()

--- a/src/flowchem/devices/knauer/azura_compact_pump.py
+++ b/src/flowchem/devices/knauer/azura_compact_pump.py
@@ -101,3 +101,14 @@ class AzuraCompactPump(HPLCPump):
             bool: True if the pump is running, False otherwise.
         """
         return self.hw_device.is_running()
+
+    async def get_flowrate(self) -> float:
+        """Return the current flow rate in ml/min, 0 if not pumping.
+
+        The Azura Compact has no flow sensor: FLOW? echoes the setpoint register rather
+        than an independently measured value, so this reflects the commanded rate while
+        running. Always non-negative, as this pump cannot withdraw.
+        """
+        if not self.hw_device.is_running():
+            return 0.0
+        return await self.hw_device.get_flow_rate()

--- a/src/flowchem/devices/knauer/knauer_autosampler.py
+++ b/src/flowchem/devices/knauer/knauer_autosampler.py
@@ -143,7 +143,9 @@ def send_until_acknowledged(max_reaction_time=15):
                 except ASBusyError:
                     # If the device is busy, wait and retry
                     elapsed_time = time.time() - start_time
-                    remaining_time = 10 - elapsed_time
+                    remaining_time = max_reaction_time - elapsed_time
+                    if remaining_time > 0:
+                        await asyncio.sleep(0.4)
             raise ASError("Maximum reaction time exceeded")
 
         return wrapper
@@ -385,6 +387,7 @@ class KnauerAutosampler(FlowchemDevice):
         port: str | None = None,
         _syringe_volume: str = "",
         tray_type: str = "",
+        initialize_hardware: bool = True,
         **kwargs,
     ):
         # Ensure only one communication mode is set
@@ -467,6 +470,7 @@ class KnauerAutosampler(FlowchemDevice):
         self.autosampler_id = autosampler_id
         self.name = f"AutoSampler ID: {self.autosampler_id}" if name is None else name
         self.tray_type = tray_type
+        self.initialize_hardware = initialize_hardware
         self._syringe_volume = _syringe_volume_ if _syringe_volume_ else _syringe_volume
         self.device_info = DeviceInfo(
             authors=[jakob, miguel, samuel_saraiva],
@@ -618,17 +622,21 @@ class KnauerAutosampler(FlowchemDevice):
 
     async def initialize(self):
         """Sets initial positions."""
-        errors = await self.get_errors()
-        if errors:
-            logger.info(f"On init Error: {errors} was present")
-        await self.reset_errors()
-        # Sets initial positions of needle and valve
-        await self._move_needle_vertical(NeedleVerticalPositions.UP.name)  # type: ignore
-        await self._move_needle_horizontal(NeedleHorizontalPosition.WASTE.name)  # type: ignore
-        await self.syringe_valve_position(SyringeValvePositions.WASTE.name)  # type: ignore
-        await self.injector_valve_position(InjectorValvePositions.LOAD.name)  # type: ignore
-
-        logger.info("Knauer AutoSampler device was successfully initialized!")
+        if self.initialize_hardware:
+            errors = await self.get_errors()
+            if errors:
+                logger.info(f"On init Error: {errors} was present")
+            await self.reset_errors()
+            # Sets initial positions of needle and valve
+            await self._move_needle_vertical(NeedleVerticalPositions.UP.name)  # type: ignore
+            await self._move_needle_horizontal(NeedleHorizontalPosition.WASTE.name)  # type: ignore
+            await self.syringe_valve_position(SyringeValvePositions.WASTE.name)  # type: ignore
+            await self.injector_valve_position(InjectorValvePositions.LOAD.name)  # type: ignore
+            logger.info("Knauer AutoSampler device was successfully initialized!")
+        else:
+            logger.info(
+                "Knauer AutoSampler hardware initialization skipped (initialize_hardware=False)."
+            )
         self.components.extend(
             [
                 AutosamplerGantry3D("gantry3D", self),

--- a/src/flowchem/devices/knauer/knauer_autosampler_component.py
+++ b/src/flowchem/devices/knauer/knauer_autosampler_component.py
@@ -63,6 +63,7 @@ class AutosamplerGantry3D(Gantry3D):
         self.add_api_route(
             "/needle_vertical_offset", self.needle_vertical_offset, methods=["PUT"]
         )
+        self.add_api_route("/tray_position", self.tray_position, methods=["PUT"])
 
     async def set_needle_position(self, position: str = "") -> bool:
         """
@@ -322,6 +323,23 @@ class AutosamplerGantry3D(Gantry3D):
             return ReachabilityStatus.ONLINE
         except Exception:
             return ReachabilityStatus.OFFLINE
+
+    async def tray_position(self, position: str = "") -> bool:
+        """
+        Move the tray to a predefined tray position.
+
+        position:
+            HOME
+            EXCHANGE_NEEDLE
+            TRAY_FRONT
+        """
+        if position is None or position == "":
+            raise ValueError("position must be provided")
+        success = await self.hw_device._move_tray("NO_PLATE", position)
+        if success:
+            logger.info(f"Tray moved successfully to position: {position}")
+            return True
+        return False
 
 
 class AutosamplerPump(SyringePump):

--- a/src/flowchem/devices/knauer/knauer_valve.py
+++ b/src/flowchem/devices/knauer/knauer_valve.py
@@ -41,8 +41,19 @@ class KnauerValve(KnauerEthernetDevice, FlowchemDevice):
     DIP switch for valve selection
     """
 
-    def __init__(self, ip_address=None, mac_address=None, **kwargs) -> None:
-        super().__init__(ip_address, mac_address, **kwargs)
+    def __init__(
+        self,
+        ip_address=None,
+        mac_address=None,
+        persistent_connection: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            ip_address,
+            mac_address,
+            persistent_connection=persistent_connection,
+            **kwargs,
+        )
         self.eol = b"\r\n"
         self.device_info = DeviceInfo(
             authors=[dario, jakob, wei_hsin],

--- a/src/flowchem/sim/devices/hamilton/ml600_sim.py
+++ b/src/flowchem/sim/devices/hamilton/ml600_sim.py
@@ -445,6 +445,8 @@ class ML600Sim(ML600):
         """
         dual_syringe: bool = config.pop("dual_syringe", False)
         syringe_volume: str = config.pop("syringe_volume", "10 ml")
+        left_syringe_volume: str = config.pop("left_syringe_volume", "")
+        right_syringe_volume: str = config.pop("right_syringe_volume", "")
         address: int = int(config.pop("address", 1))
         name: str = config.pop("name", "sim-ml600")
         firmware_version: str = config.pop("firmware_version", "NV01.02.3")
@@ -466,6 +468,8 @@ class ML600Sim(ML600):
         instance = cls(
             pump_io=sim_io,
             syringe_volume=syringe_volume,
+            left_syringe_volume=left_syringe_volume,
+            right_syringe_volume=right_syringe_volume,
             name=name,
             address=address,
             **extra_config,

--- a/src/flowchem/sim/devices/harvardapparatus/elite11_sim.py
+++ b/src/flowchem/sim/devices/harvardapparatus/elite11_sim.py
@@ -137,6 +137,15 @@ class SimulatedHarvardApparatusPumpIO(HarvardApparatusPumpIO):
             # Status query
             return self._make_reply()
 
+        if c == "crate":
+            if self._sim_status is PumpStatus.INFUSING:
+                return self._make_reply(f"Infusing at {self._sim_flow_rate:.3f} ml/min")
+            if self._sim_status is PumpStatus.WITHDRAWING:
+                return self._make_reply(
+                    f"Withdrawing at {self._sim_withdraw_rate:.3f} ml/min"
+                )
+            return self._make_reply()
+
         if c == "metrics":
             lines = [
                 f"0{self._address}:  Pump type          Pump 11",

--- a/src/flowchem/sim/devices/oceanoptics/flame_sim.py
+++ b/src/flowchem/sim/devices/oceanoptics/flame_sim.py
@@ -67,7 +67,11 @@ class FlameOpticalSim(FlowchemDevice):
 
     def _synthetic_intensities(self) -> np.ndarray:
         """A synthetic spectrum: a gaussian peak on top of a flat baseline."""
-        peak = self.max_intensity * 0.5 * np.exp(-((self.wavelengths - 500.0) ** 2) / (2 * 40.0**2))
+        peak = (
+            self.max_intensity
+            * 0.5
+            * np.exp(-((self.wavelengths - 500.0) ** 2) / (2 * 40.0**2))
+        )
         baseline = self.max_intensity * 0.01
         return peak + baseline
 
@@ -80,7 +84,9 @@ class FlameOpticalSim(FlowchemDevice):
     async def get_spectrum(self):
         return self._synthetic_intensities()
 
-    async def get_intensity(self, absolute: bool = False, scans_to_average: int | None = None):
+    async def get_intensity(
+        self, absolute: bool = False, scans_to_average: int | None = None
+    ):
         intensities = self._synthetic_intensities()
         if absolute:
             return intensities.tolist()


### PR DESCRIPTION
initialize_hardware flag on KnauerAutosampler — skips physical actuation on initialize() while still registering all API components.

send_until_acknowledged bugfix — the retry decorator now respects its own max_reaction_time and sleeps between ASBusyError retries instead of busy-looping. /tray_position endpoint on the autosampler gantry component (HOME/EXCHANGE_NEEDLE/TRAY_FRONT).

Configurable non-persistent connection mode on KnauerEthernetDevice, opt-in via persistent_connection=False (default stays True, so no existing valve config changes behavior) — implemented with native asyncio, not blocking sockets.

ML600 per-drive syringe volumes (left_syringe_volume/right_syringe_volume) — plus the fix to ml600_pump.py that the original PR was missing, where syringe_volume moved from an attribute to a method; without it, withdraw() would have crashed with a TypeError on every ML600 pump.