### PR TITLE
add generic is_idle endpoint with real per-device checks

### DIFF
--- a/docs/user-guides/reference/devices/pumps/runze_syringe_pump.md
+++ b/docs/user-guides/reference/devices/pumps/runze_syringe_pump.md
@@ -34,6 +34,14 @@ Position is tracked in steps from home (the plunger's reset optocoupler, at 0 mL
 `total_steps` (at `syringe_volume`). `infuse` moves the plunger toward home; `withdraw`
 moves it away from home, mirroring the vendor's "Injection"/"Suction" terminology.
 
+## Waiting for the pump to finish
+When you send an `infuse` or `withdraw` command to this pump, you don't get a response back
+until the plunger has *actually finished moving*. This is not a choice made in how the driver
+was written — it's simply how this pump's hardware behaves: it doesn't report anything back to
+the computer until the movement is complete. So if your script sends the command and then
+immediately moves on to the next step, you can be confident the pump is already done — there
+is no need to add an extra wait or check "is it still moving?" yourself.
+
 ## Valve positions
 The built-in valve position naming follows the general convention of flowchem: distribution
 valves have positions from '1' to 'n', where n is the total number of available ports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flowchem"
-version = "1.1.2"
+version = "1.1.3"
 
 description = "Flowchem is a library to control instruments and devices commonly found in chemistry labs via an interoperable web API."
 readme = "README.md"

--- a/src/flowchem/components/flowchem_component.py
+++ b/src/flowchem/components/flowchem_component.py
@@ -75,6 +75,7 @@ class FlowchemComponent:
         )
 
         self.add_api_route("/is-reachable", self.is_reachable, methods=["GET"])
+        self.add_api_route("/is-idle", self.is_idle, methods=["GET"])
 
     @property
     def router(self):
@@ -130,3 +131,11 @@ class FlowchemComponent:
         report the device as offline.
         """
         return ReachabilityStatus.UNKNOWN
+
+    async def is_idle(self) -> bool:
+        """Check whether any in-progress physical action has finished.
+
+        Subclasses should override this with a real hardware busy/idle probe where
+        available. Returns True by default when completion can't be verified.
+        """
+        return True

--- a/src/flowchem/devices/custom/peltier_cooler_component.py
+++ b/src/flowchem/devices/custom/peltier_cooler_component.py
@@ -36,6 +36,10 @@ class PeltierCoolerTemperatureControl(TemperatureControl):
         else:
             return False
 
+    async def is_idle(self) -> bool:
+        """Check whether the set temperature target has been reached."""
+        return await self.is_target_reached() is not False
+
     async def get_temperature_setpoint(self) -> float:
         """Return the current set temperature from the Peltier parameter list."""
         params = await self.hw_device.get_parameters()

--- a/src/flowchem/devices/hamilton/ml600_pump.py
+++ b/src/flowchem/devices/hamilton/ml600_pump.py
@@ -220,6 +220,10 @@ class ML600Pump(SyringePump):
         logger.debug("wait until pump idle")
         return await self.hw_device.wait_until_idle(pump=self.pump_code)
 
+    async def is_idle(self) -> bool:
+        """Check whether the syringe has finished its current move."""
+        return await self.hw_device.is_idle(self.pump_code)
+
     async def set_to_volume_dual_syringes(
         self, target_volume: str, rate_left: str, rate_right: str, connection: str = ""
     ):

--- a/src/flowchem/devices/hamilton/ml600_valve.py
+++ b/src/flowchem/devices/hamilton/ml600_valve.py
@@ -40,6 +40,10 @@ class ML600LeftValve(FourPortFivePositionValve):
             translated = round(int(raw_position) / 45)
         return str(translated)
 
+    async def is_idle(self) -> bool:
+        """Check whether the valve has finished switching."""
+        return not await self.hw_device.get_valve_status(self.identifier)
+
 
 class ML600RightValve(ThreePortFourPositionValve):
     """
@@ -86,3 +90,7 @@ class ML600RightValve(ThreePortFourPositionValve):
                 translated -= 2
 
         return str(translated)
+
+    async def is_idle(self) -> bool:
+        """Check whether the valve has finished switching."""
+        return not await self.hw_device.get_valve_status(self.identifier)

--- a/src/flowchem/devices/harvardapparatus/elite11_pump.py
+++ b/src/flowchem/devices/harvardapparatus/elite11_pump.py
@@ -40,6 +40,15 @@ class Elite11PumpOnly(SyringePump):
         """
         return await self.hw_device.is_moving()
 
+    async def is_idle(self) -> bool:
+        """
+        Check whether the pump has finished its current move.
+
+        Returns:
+            bool: True if the pump is not moving, False otherwise.
+        """
+        return not await self.hw_device.is_moving()
+
     async def stop(self):
         """Stop pump."""
         await self.hw_device.stop()

--- a/src/flowchem/devices/heidolph/hei_connect_components.py
+++ b/src/flowchem/devices/heidolph/hei_connect_components.py
@@ -97,6 +97,10 @@ class HeiConnectTemperatureControl(TemperatureControl):
     async def is_target_reached(self) -> bool:
         return await self.hw_device.is_temperature_target_reached()
 
+    async def is_idle(self) -> bool:
+        """Check whether the set temperature target has been reached."""
+        return await self.is_target_reached()
+
     async def get_heating_mode(self) -> HeatingMode:
         """Get the heating mode.
         precise - ptsensor

--- a/src/flowchem/devices/huber/huber_temperature_control.py
+++ b/src/flowchem/devices/huber/huber_temperature_control.py
@@ -54,6 +54,10 @@ class HuberTemperatureControl(TemperatureControl):
         """
         return await self.hw_device.target_reached()
 
+    async def is_idle(self) -> bool:
+        """Check whether the set temperature target has been reached."""
+        return await self.hw_device.target_reached()
+
     async def power_on(self):
         """
         Turn on the temperature control.

--- a/src/flowchem/devices/knauer/knauer_autosampler_component.py
+++ b/src/flowchem/devices/knauer/knauer_autosampler_component.py
@@ -190,6 +190,10 @@ class AutosamplerGantry3D(Gantry3D):
         else:
             return False
 
+    async def is_idle(self) -> bool:
+        """Check whether the 3D gantry/needle has finished moving."""
+        return not await self.is_needle_running()
+
     async def tray_temperature(
         self, temperature: int | float | str | None = None
     ) -> bool:
@@ -389,6 +393,11 @@ class AutosamplerPump(SyringePump):
         else:
             return False
 
+    async def is_idle(self) -> bool:
+        """Check whether the built-in syringe/syringe valve has finished moving."""
+        status = await self.hw_device.get_status()
+        return status != "SYRINGE_OR_SYRINGE_VALVE_RUNNING"
+
     async def stop(self) -> bool:
         """Stop the simulated pump operation."""
         return True
@@ -549,3 +558,12 @@ class AutosamplerSyringeValve(FourPortDistributionValve):
         success = await self.hw_device.syringe_valve_position(port=position)
         if success:
             logger.info(f"Syringe valve moved successfully to position: {position}")
+
+    async def is_idle(self) -> bool:
+        """Check whether the syringe valve has finished switching.
+
+        No status distinct from the syringe pump exists on this hardware -
+        the same combined status bit covers both.
+        """
+        status = await self.hw_device.get_status()
+        return status != "SYRINGE_OR_SYRINGE_VALVE_RUNNING"

--- a/src/flowchem/devices/magritek/spinsolve.py
+++ b/src/flowchem/devices/magritek/spinsolve.py
@@ -80,6 +80,7 @@ class Spinsolve(FlowchemDevice):
         self.sample, self.solvent = sample_name, solvent
         self.protocols: dict[str, dict] = {}
         self.user_data = {"control_software": "flowchem"}
+        self._protocol_running = False
 
         # XML schema for reply validation. Reply validation is completely optional!
         if xml_schema is None:

--- a/src/flowchem/devices/magritek/spinsolve_control.py
+++ b/src/flowchem/devices/magritek/spinsolve_control.py
@@ -56,6 +56,10 @@ class SpinsolveControl(NMRControl):
         except Exception:
             return ReachabilityStatus.OFFLINE
 
+    async def is_idle(self) -> bool:
+        """Check whether a protocol/acquisition is currently running."""
+        return not await self.hw_device.is_protocol_running()
+
     async def acquire_spectrum(
         self,
         background_tasks: BackgroundTasks,

--- a/src/flowchem/devices/mettlertoledo/icir_control.py
+++ b/src/flowchem/devices/mettlertoledo/icir_control.py
@@ -84,6 +84,10 @@ class IcIRControl(IRControl):
         """
         return await self.hw_device.stop_experiment()
 
+    async def is_idle(self) -> bool:
+        """Check whether an IR scan is currently running."""
+        return await self.hw_device.probe_status() != "Running"
+
     async def is_reachable(self) -> ReachabilityStatus:
         """Return ONLINE if the iCIR OPC UA connection to the instrument is active."""
         connected = await self.hw_device.is_iCIR_connected()

--- a/src/flowchem/devices/runze/runze_syringe_pump_component.py
+++ b/src/flowchem/devices/runze/runze_syringe_pump_component.py
@@ -45,6 +45,10 @@ class RunzeSyringePumpComponent(SyringePump):
         """Is the plunger or the built-in valve currently moving?"""
         return await self.hw_device.is_moving()
 
+    async def is_idle(self) -> bool:
+        """Check whether the plunger has finished its current move."""
+        return await self.hw_device.get_status() == "00"
+
     async def stop(self) -> bool:
         """Strong stop: halts both the plunger and the built-in valve."""
         return await self.hw_device.stop()

--- a/src/flowchem/devices/runze/runze_valve_component.py
+++ b/src/flowchem/devices/runze/runze_valve_component.py
@@ -67,6 +67,10 @@ class Runze6PortDistributionValve(SixPortDistributionValve):
         """Move valve to position."""
         return await self.hw_device.set_raw_position(position=position)
 
+    async def is_idle(self) -> bool:
+        """Check whether the valve has finished switching."""
+        return await self.hw_device.get_status() == "00"
+
 
 class Runze8PortDistributionValve(EightPortDistributionValve):
     """RunzeValve of type Eight_Port_Distribution."""
@@ -111,6 +115,10 @@ class Runze8PortDistributionValve(EightPortDistributionValve):
     async def set_monitor_position(self, position: str) -> bool:
         """Move valve to position."""
         return await self.hw_device.set_raw_position(position=position)
+
+    async def is_idle(self) -> bool:
+        """Check whether the valve has finished switching."""
+        return await self.hw_device.get_status() == "00"
 
 
 class Runze10PortDistributionValve(TenPortDistributionValve):
@@ -157,6 +165,10 @@ class Runze10PortDistributionValve(TenPortDistributionValve):
         """Move valve to position."""
         return await self.hw_device.set_raw_position(position=position)
 
+    async def is_idle(self) -> bool:
+        """Check whether the valve has finished switching."""
+        return await self.hw_device.get_status() == "00"
+
 
 class Runze12PortDistributionValve(TwelvePortDistributionValve):
     """RunzeValve of type Twelve_Port_Distribution."""
@@ -202,6 +214,10 @@ class Runze12PortDistributionValve(TwelvePortDistributionValve):
         """Move valve to position."""
         return await self.hw_device.set_raw_position(position=position)
 
+    async def is_idle(self) -> bool:
+        """Check whether the valve has finished switching."""
+        return await self.hw_device.get_status() == "00"
+
 
 class Runze16PortDistributionValve(SixteenPortDistributionValve):
     """RunzeValve of type Sixteen_Port_Distribution"""
@@ -246,3 +262,7 @@ class Runze16PortDistributionValve(SixteenPortDistributionValve):
     async def set_monitor_position(self, position: str) -> bool:
         """Move valve to position."""
         return await self.hw_device.set_raw_position(position=position)
+
+    async def is_idle(self) -> bool:
+        """Check whether the valve has finished switching."""
+        return await self.hw_device.get_status() == "00"

--- a/src/flowchem/devices/trinamic/tmcm1110_component.py
+++ b/src/flowchem/devices/trinamic/tmcm1110_component.py
@@ -58,6 +58,10 @@ class TMCM1110FractionCollector(FlowchemComponent):
         """Return whether the target position has been reached."""
         return await self.hw_device.is_target_reached()
 
+    async def is_idle(self) -> bool:
+        """Check whether the collector has finished moving to its target position."""
+        return await self.hw_device.is_target_reached()
+
     async def is_reachable(self) -> ReachabilityStatus:
         """Return ONLINE if the TMCM-1110 responds over serial."""
         try:

--- a/src/flowchem/devices/trinamic/tmcm1111_component.py
+++ b/src/flowchem/devices/trinamic/tmcm1111_component.py
@@ -58,6 +58,10 @@ class TMCM1111FractionCollector(FlowchemComponent):
         """Return whether the target position has been reached."""
         return await self.hw_device.is_target_reached()
 
+    async def is_idle(self) -> bool:
+        """Check whether the collector has finished moving to its target position."""
+        return await self.hw_device.is_target_reached()
+
     async def is_reachable(self) -> ReachabilityStatus:
         """Return ONLINE if the TMCM-1111 responds over serial."""
         try:

--- a/src/flowchem/devices/vacuubrand/cvc3000_pressure_control.py
+++ b/src/flowchem/devices/vacuubrand/cvc3000_pressure_control.py
@@ -101,6 +101,10 @@ class CVC3000PressureControl(PressureControl):
         status = await self.hw_device.status()
         return status.state == PumpState.VACUUM_REACHED
 
+    async def is_idle(self) -> bool:
+        """Check whether the target pressure has been reached."""
+        return await self.is_target_reached()
+
     async def power_on(self) -> str:
         """
         Turn on the pressure control.

--- a/src/flowchem/devices/vapourtec/r2_components_control.py
+++ b/src/flowchem/devices/vapourtec/r2_components_control.py
@@ -91,6 +91,10 @@ class R4Reactor(TemperatureControl):
         else:
             return False
 
+    async def is_idle(self) -> bool:
+        """Check whether the set temperature target has been reached (or none is set)."""
+        return await self.is_target_reached() is not False
+
     async def power_on(self):
         """Turn on temperature control."""
         return await self.hw_device.power_on()

--- a/src/flowchem/devices/vapourtec/r4_heater_channel_control.py
+++ b/src/flowchem/devices/vapourtec/r4_heater_channel_control.py
@@ -67,6 +67,10 @@ class R4HeaterChannelControl(TemperatureControl):
         status = await self.hw_device.get_status(self.channel)
         return status.state == "S"
 
+    async def is_idle(self) -> bool:
+        """Check whether the set temperature target has been reached for this channel."""
+        return await self.is_target_reached()
+
     async def power_on(self):
         """
         Turn on the temperature control for this channel.


### PR DESCRIPTION
Add FlowchemComponent.is_idle() + a shared "/is-idle" GET route, mirroring
the existing "/is-reachable" pattern: defaults to True ("can't verify,
assume finished") and is overridable per component.

Override it in 23 components with a real, already-existing hardware
busy/target-reached signal - no new protocol logic invented, only reuse
of status reads the drivers already had:
- Hamilton ML600 (pump + both valve classes)
- Harvard Elite11 pump
- Knauer autosampler (gantry, pump, syringe valve)
- Runze SY-01 syringe pump + all 5 SV-06 distribution valve classes
- Huber chiller, Vapourtec R4Heater/R2 reactor, Heidolph, Vacuubrand CVC3000
- Magritek Spinsolve, Mettler-Toledo iCIR
- Custom Peltier cooler, Trinamic TMCM1110/1111 fraction collectors

Every other component in the repo was individually reviewed and
deliberately left on the True default (continuous/ongoing operations,
no genuine busy signal in the driver, already hardware-synchronous
writes, read-only endpoints, or simulation stubs) - see
hardware_sync_audit.md for the full per-component rationale.

Also fixes a latent bug in Spinsolve: _protocol_running was read by
is_protocol_running() but never initialized in __init__, so calling it
before any protocol had run raised AttributeError.