### PR TITLE
Fix Knauer valve connection mappings

### DIFF
--- a/src/flowchem/devices/knauer/knauer_autosampler_component.py
+++ b/src/flowchem/devices/knauer/knauer_autosampler_component.py
@@ -531,7 +531,7 @@ class AutosamplerSyringeValve(FourPortDistributionValve):
         Returns:
             int: The mapped position.
         """
-        position_mapping = {0: "NEEDLE", 1: "WASH", 2: "WASH_PORT2", 3: "WASTE"}
+        position_mapping = {0: "NEEDLE", 1: "WASH_PORT2", 2: "WASTE", 3: "WASH"}
         if reverse:
             return str(
                 [
@@ -552,8 +552,8 @@ class AutosamplerSyringeValve(FourPortDistributionValve):
 
         Returns:
             position (str): The current position:
-            NEEDLE (position 0).
-            WASH (position 1).
+            NEEDLE (position 1).
+            WASH (position 4).
             WASH_PORT2 (position 2).
             WASTE (position 3).
         """
@@ -568,8 +568,8 @@ class AutosamplerSyringeValve(FourPortDistributionValve):
 
         Args:
             position (str): The desired position:
-            NEEDLE (position 0).
-            WASH (position 1).
+            NEEDLE (position 1).
+            WASH (position 4).
             WASH_PORT2 (position 2).
             WASTE (position 3).
         """

--- a/src/flowchem/devices/knauer/knauer_valve_component.py
+++ b/src/flowchem/devices/knauer/knauer_valve_component.py
@@ -47,7 +47,9 @@ class KnauerInjectionValve(SixPortTwoPositionValve):
         INJECT = "I"
 
     def _change_connections(self, raw_position: str | int, reverse: bool = False):
-        position_mapping = {0: "L", 1: "I"}
+        # Knauer reports LOAD/INJECT as L/I, but the physical port pairing for
+        # L corresponds to the second generic six-port valve state.
+        position_mapping = {0: "I", 1: "L"}
         if reverse:
             return str(
                 [


### PR DESCRIPTION
## Summary

This PR fixes incorrect connection mappings for Knauer valves.

The changes address two mapping issues:

- `KnauerInjectionValve`: corrects the generic valve-state mapping for `L` / `I` so the Flowchem connection model matches the physical port pairing.
- `AutosamplerSyringeValve`: corrects the syringe valve position mapping for `NEEDLE`, `WASH`, `WASH_PORT2`, and `WASTE`.

## Motivation

The previous mappings caused Flowchem API responses and requested valve connections to disagree with the verified physical valve states on the lab hardware.

This affected both:

- reading the current valve connection state
- setting a valve position through the generic Flowchem valve API

## Scope

This is a bugfix for existing Knauer valve components.

No new device type is added, and the Flowchem configuration format is unchanged. Therefore no new device configuration documentation is included.

## Testing

Tested manually against the lab Knauer hardware through the Flowchem HTTP API.

Verified that:

- autosampler syringe valve monitor positions map to the expected physical ports
- generic `connect` requests map to the expected valve positions
- Knauer injection valve `L` / `I` states report the corrected connection model
